### PR TITLE
Navigate to runs page with queue filter

### DIFF
--- a/apps/app/src/app/queues/_components/queues-table.tsx
+++ b/apps/app/src/app/queues/_components/queues-table.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { formatDuration } from "date-fns";
 import { Search } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { getQueuesTableApiRoute } from "~/app/api/queues/table/schemas";
 import { Badge } from "~/components/ui/badge";
@@ -20,6 +21,7 @@ import { QueueActions } from "./queue-actions";
 import { type TimePeriod, TimePeriodSelector } from "./time-period-selector";
 
 export function QueuesTable() {
+  const router = useRouter();
   const [options, setOptions] = useState<{
     cursor: string | null;
     search: string;
@@ -29,6 +31,10 @@ export function QueuesTable() {
     search: "",
     timePeriod: "1",
   });
+
+  const handleQueueClick = (queueName: string) => {
+    router.push(`/runs?queue=${encodeURIComponent(queueName)}`);
+  };
 
   const { data } = useQuery({
     queryKey: ["queues/table", options],
@@ -78,7 +84,11 @@ export function QueuesTable() {
         </TableHeader>
         <TableBody>
           {data?.queues.map((queue) => (
-            <TableRow key={queue.name}>
+            <TableRow 
+              key={queue.name}
+              className="cursor-pointer hover:bg-muted/50"
+              onClick={() => handleQueueClick(queue.name)}
+            >
               <TableCell className="font-medium">{queue.name}</TableCell>
               <TableCell>
                 <Badge
@@ -112,7 +122,7 @@ export function QueuesTable() {
                   {queue.completedJobs}
                 </span>
               </TableCell>
-              <TableCell>
+              <TableCell onClick={(e) => e.stopPropagation()}>
                 <QueueActions
                   queueName={queue.name}
                   isPaused={queue.isPaused}

--- a/apps/app/src/app/runs/_components/runs-table.tsx
+++ b/apps/app/src/app/runs/_components/runs-table.tsx
@@ -18,11 +18,19 @@ import { apiFetch, cn } from "~/lib/utils";
 import { RunsFilters } from "./runs-filters";
 import type { TRunFilters } from "./types";
 
-export function RunsTable() {
+type RunsTableProps = {
+  searchParams?: { [key: string]: string | string[] | undefined };
+};
+
+export function RunsTable({ searchParams }: RunsTableProps) {
+  const initialQueue = typeof searchParams?.queue === 'string' ? searchParams.queue : "all";
+  const initialStatus = typeof searchParams?.status === 'string' ? searchParams.status : "all";
+  const initialSearch = typeof searchParams?.search === 'string' ? searchParams.search : "";
+  
   const [filters, setFilters] = useState<TRunFilters>({
-    queue: "all",
-    status: "all",
-    search: "",
+    queue: initialQueue,
+    status: initialStatus,
+    search: initialSearch,
     cursor: null,
     limit: 20,
   });

--- a/apps/app/src/app/runs/page.tsx
+++ b/apps/app/src/app/runs/page.tsx
@@ -3,17 +3,19 @@ import { PageTitle } from "~/components/page-title";
 import { RunsTable } from "./_components/runs-table";
 
 type RunsPageProps = {
-  searchParams: { [key: string]: string | string[] | undefined };
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-export default function RunsPage({ searchParams }: RunsPageProps) {
+export default async function RunsPage({ searchParams }: RunsPageProps) {
+  const resolvedSearchParams = await searchParams;
+  
   return (
     <PageContainer>
       <PageTitle
         title="Job Runs"
         description="View and manage all job executions"
       />
-      <RunsTable searchParams={searchParams} />
+      <RunsTable searchParams={resolvedSearchParams} />
     </PageContainer>
   );
 }

--- a/apps/app/src/app/runs/page.tsx
+++ b/apps/app/src/app/runs/page.tsx
@@ -2,14 +2,18 @@ import { PageContainer } from "~/components/page-container";
 import { PageTitle } from "~/components/page-title";
 import { RunsTable } from "./_components/runs-table";
 
-export default function RunsPage() {
+type RunsPageProps = {
+  searchParams: { [key: string]: string | string[] | undefined };
+};
+
+export default function RunsPage({ searchParams }: RunsPageProps) {
   return (
     <PageContainer>
       <PageTitle
         title="Job Runs"
         description="View and manage all job executions"
       />
-      <RunsTable />
+      <RunsTable searchParams={searchParams} />
     </PageContainer>
   );
 }


### PR DESCRIPTION
Enable clicking on queue table rows to redirect to the runs page with the selected queue filter pre-applied.

---
<a href="https://cursor.com/background-agent?bcId=bc-31abb3ee-a718-4e69-9de1-f15f97d83133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-31abb3ee-a718-4e69-9de1-f15f97d83133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

