### PR TITLE
Add job run stats graph and switch to clickhouse

### DIFF
--- a/apps/app/src/app/api/queues/table/route.ts
+++ b/apps/app/src/app/api/queues/table/route.ts
@@ -1,9 +1,6 @@
-import {
-  jobSchedulersTable,
-  queuesTable,
-} from "@better-bull-board/db";
-import { db } from "@better-bull-board/db/server";
 import { getQueueStatsWithChart } from "@better-bull-board/clickhouse";
+import { jobSchedulersTable, queuesTable } from "@better-bull-board/db";
+import { db } from "@better-bull-board/db/server";
 import { and, eq, gt, ilike, sql } from "drizzle-orm";
 import { createAuthenticatedApiRoute } from "~/lib/utils/server";
 import { getQueuesTableApiRoute } from "./schemas";
@@ -44,7 +41,9 @@ export const POST = createAuthenticatedApiRoute({
     // Get job run stats from ClickHouse
     const queueNames = rows.map((row) => row.name);
     const timePeriodDays = Number(timePeriod);
-    const dateFrom = new Date(Date.now() - timePeriodDays * 24 * 60 * 60 * 1000);
+    const dateFrom = new Date(
+      Date.now() - timePeriodDays * 24 * 60 * 60 * 1000,
+    );
     const dateTo = new Date();
 
     const queueStats = await getQueueStatsWithChart({
@@ -66,7 +65,7 @@ export const POST = createAuthenticatedApiRoute({
           completedJobs: 0,
           chartData: [],
         };
-        
+
         return {
           name: row.name,
           isPaused: row.isPaused,

--- a/apps/app/src/app/api/queues/table/route.ts
+++ b/apps/app/src/app/api/queues/table/route.ts
@@ -1,9 +1,9 @@
 import {
-  jobRunsTable,
   jobSchedulersTable,
   queuesTable,
 } from "@better-bull-board/db";
 import { db } from "@better-bull-board/db/server";
+import { getQueueStatsWithChart } from "@better-bull-board/clickhouse";
 import { and, eq, gt, ilike, sql } from "drizzle-orm";
 import { createAuthenticatedApiRoute } from "~/lib/utils/server";
 import { getQueuesTableApiRoute } from "./schemas";
@@ -13,6 +13,7 @@ export const POST = createAuthenticatedApiRoute({
   async handler(input) {
     const { cursor, search, timePeriod, limit } = input;
 
+    // Get queue info from Postgres (basic queue data)
     const rows = await db
       .select({
         id: queuesTable.id,
@@ -20,28 +21,17 @@ export const POST = createAuthenticatedApiRoute({
         isPaused: queuesTable.isPaused,
         pattern: jobSchedulersTable.pattern,
         every: jobSchedulersTable.every,
-        activeJobs: sql<number>`COUNT(*) FILTER (WHERE ${jobRunsTable.status} = 'active' AND ${jobRunsTable.createdAt} > NOW() - INTERVAL '${sql.raw(timePeriod)} day')`,
-        failedJobs: sql<number>`COUNT(*) FILTER (WHERE ${jobRunsTable.status} = 'failed' AND ${jobRunsTable.createdAt} > NOW() - INTERVAL '${sql.raw(timePeriod)} day')`,
-        completedJobs: sql<number>`COUNT(*) FILTER (WHERE ${jobRunsTable.status} = 'completed' AND ${jobRunsTable.createdAt} > NOW() - INTERVAL '${sql.raw(timePeriod)} day')`,
       })
       .from(queuesTable)
       .leftJoin(
         jobSchedulersTable,
         eq(jobSchedulersTable.queueId, queuesTable.id),
       )
-      .leftJoin(jobRunsTable, eq(jobRunsTable.queue, queuesTable.name))
       .where(
         and(
           cursor ? gt(queuesTable.id, cursor) : undefined,
           search ? ilike(queuesTable.name, `%${search}%`) : undefined,
         ),
-      )
-      .groupBy(
-        queuesTable.id,
-        queuesTable.name,
-        queuesTable.isPaused,
-        jobSchedulersTable.pattern,
-        jobSchedulersTable.every,
       )
       .orderBy(queuesTable.id)
       .limit(limit ?? 20);
@@ -51,16 +41,43 @@ export const POST = createAuthenticatedApiRoute({
       .from(queuesTable)
       .where(search ? ilike(queuesTable.name, `%${search}%`) : undefined);
 
+    // Get job run stats from ClickHouse
+    const queueNames = rows.map((row) => row.name);
+    const timePeriodDays = Number(timePeriod);
+    const dateFrom = new Date(Date.now() - timePeriodDays * 24 * 60 * 60 * 1000);
+    const dateTo = new Date();
+
+    const queueStats = await getQueueStatsWithChart({
+      queueNames,
+      dateFrom,
+      dateTo,
+      timePeriod: timePeriodDays,
+    });
+
+    // Create a map for quick lookup
+    const statsMap = new Map(queueStats.map((stat) => [stat.queueName, stat]));
+
     return {
-      queues: rows.map((row) => ({
-        name: row.name,
-        isPaused: row.isPaused,
-        pattern: row.pattern,
-        every: row.every,
-        activeJobs: Number(row.activeJobs ?? 0),
-        failedJobs: Number(row.failedJobs ?? 0),
-        completedJobs: Number(row.completedJobs ?? 0),
-      })),
+      queues: rows.map((row) => {
+        const stats = statsMap.get(row.name) ?? {
+          queueName: row.name,
+          activeJobs: 0,
+          failedJobs: 0,
+          completedJobs: 0,
+          chartData: [],
+        };
+        
+        return {
+          name: row.name,
+          isPaused: row.isPaused,
+          pattern: row.pattern,
+          every: row.every,
+          activeJobs: stats.activeJobs,
+          failedJobs: stats.failedJobs,
+          completedJobs: stats.completedJobs,
+          chartData: stats.chartData,
+        };
+      }),
       nextCursor: rows.length ? (rows[rows.length - 1]?.id ?? null) : null,
       total: Number(total?.count ?? 0),
     };

--- a/apps/app/src/app/api/queues/table/schemas.ts
+++ b/apps/app/src/app/api/queues/table/schemas.ts
@@ -18,6 +18,13 @@ export const getQueuesTableOutput = z.object({
       activeJobs: z.number(),
       failedJobs: z.number(),
       completedJobs: z.number(),
+      chartData: z.array(
+        z.object({
+          timestamp: z.string(),
+          completed: z.number(),
+          failed: z.number(),
+        }),
+      ),
     }),
   ),
   nextCursor: z.string().nullable(),

--- a/apps/app/src/app/queues/_components/queue-mini-chart.tsx
+++ b/apps/app/src/app/queues/_components/queue-mini-chart.tsx
@@ -1,14 +1,6 @@
 "use client";
 
-import { format } from "date-fns";
-import {
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { Line, LineChart, ResponsiveContainer } from "recharts";
 
 interface QueueChartData {
   timestamp: string;
@@ -18,10 +10,9 @@ interface QueueChartData {
 
 interface QueueMiniChartProps {
   data: QueueChartData[];
-  timePeriod: string;
 }
 
-export function QueueMiniChart({ data, timePeriod }: QueueMiniChartProps) {
+export function QueueMiniChart({ data }: QueueMiniChartProps) {
   if (!data || data.length === 0) {
     return (
       <div className="h-16 w-32 flex items-center justify-center text-xs text-muted-foreground">
@@ -30,36 +21,6 @@ export function QueueMiniChart({ data, timePeriod }: QueueMiniChartProps) {
     );
   }
 
-  // Determine the date format based on time period
-  const getDateFormat = (timePeriod: string): string => {
-    const period = parseInt(timePeriod);
-    if (period <= 1) {
-      return "HH:mm"; // Hours for 1 day
-    } else if (period <= 7) {
-      return "MM/dd HH:mm"; // Days and hours for up to 7 days
-    } else {
-      return "MM/dd"; // Just days for longer periods
-    }
-  };
-
-  const formatTooltipLabel = (value: string): string => {
-    const date = new Date(value);
-    const period = parseInt(timePeriod);
-    
-    if (period <= 1) {
-      return format(date, "MMM dd, HH:mm");
-    } else if (period <= 7) {
-      return format(date, "MMM dd, HH:mm");
-    } else {
-      return format(date, "MMM dd, yyyy");
-    }
-  };
-
-  const formatXAxisLabel = (value: string): string => {
-    const date = new Date(value);
-    return format(date, getDateFormat(timePeriod));
-  };
-
   // Process data to ensure we have valid timestamps
   const processedData = data.map((item) => ({
     ...item,
@@ -67,40 +28,16 @@ export function QueueMiniChart({ data, timePeriod }: QueueMiniChartProps) {
   }));
 
   return (
-    <div className="h-16 w-32">
+    <div className="h-8 w-16">
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={processedData} margin={{ top: 2, right: 2, left: 2, bottom: 2 }}>
-          <XAxis 
-            dataKey="timestamp" 
-            axisLine={false}
-            tickLine={false}
-            tick={false}
-          />
-          <YAxis 
-            axisLine={false}
-            tickLine={false}
-            tick={false}
-          />
-          <Tooltip 
-            labelFormatter={formatTooltipLabel}
-            contentStyle={{
-              backgroundColor: "hsl(var(--popover))",
-              border: "1px solid hsl(var(--border))",
-              borderRadius: "6px",
-              fontSize: "12px",
-            }}
-            formatter={(value: number, name: string) => [
-              value,
-              name === "completed" ? "Completed" : "Failed"
-            ]}
-          />
+        <LineChart data={processedData}>
           <Line
             type="monotone"
             dataKey="completed"
             stroke="#10b981"
             strokeWidth={1.5}
             dot={false}
-            activeDot={{ r: 2, stroke: "#10b981", strokeWidth: 1 }}
+            activeDot={false}
           />
           <Line
             type="monotone"
@@ -108,7 +45,7 @@ export function QueueMiniChart({ data, timePeriod }: QueueMiniChartProps) {
             stroke="#ef4444"
             strokeWidth={1.5}
             dot={false}
-            activeDot={{ r: 2, stroke: "#ef4444", strokeWidth: 1 }}
+            activeDot={false}
           />
         </LineChart>
       </ResponsiveContainer>

--- a/apps/app/src/app/queues/_components/queue-mini-chart.tsx
+++ b/apps/app/src/app/queues/_components/queue-mini-chart.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { format } from "date-fns";
+import {
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+interface QueueChartData {
+  timestamp: string;
+  completed: number;
+  failed: number;
+}
+
+interface QueueMiniChartProps {
+  data: QueueChartData[];
+  timePeriod: string;
+}
+
+export function QueueMiniChart({ data, timePeriod }: QueueMiniChartProps) {
+  if (!data || data.length === 0) {
+    return (
+      <div className="h-16 w-32 flex items-center justify-center text-xs text-muted-foreground">
+        No data
+      </div>
+    );
+  }
+
+  // Determine the date format based on time period
+  const getDateFormat = (timePeriod: string): string => {
+    const period = parseInt(timePeriod);
+    if (period <= 1) {
+      return "HH:mm"; // Hours for 1 day
+    } else if (period <= 7) {
+      return "MM/dd HH:mm"; // Days and hours for up to 7 days
+    } else {
+      return "MM/dd"; // Just days for longer periods
+    }
+  };
+
+  const formatTooltipLabel = (value: string): string => {
+    const date = new Date(value);
+    const period = parseInt(timePeriod);
+    
+    if (period <= 1) {
+      return format(date, "MMM dd, HH:mm");
+    } else if (period <= 7) {
+      return format(date, "MMM dd, HH:mm");
+    } else {
+      return format(date, "MMM dd, yyyy");
+    }
+  };
+
+  const formatXAxisLabel = (value: string): string => {
+    const date = new Date(value);
+    return format(date, getDateFormat(timePeriod));
+  };
+
+  // Process data to ensure we have valid timestamps
+  const processedData = data.map((item) => ({
+    ...item,
+    timestamp: new Date(item.timestamp).toISOString(),
+  }));
+
+  return (
+    <div className="h-16 w-32">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={processedData} margin={{ top: 2, right: 2, left: 2, bottom: 2 }}>
+          <XAxis 
+            dataKey="timestamp" 
+            axisLine={false}
+            tickLine={false}
+            tick={false}
+          />
+          <YAxis 
+            axisLine={false}
+            tickLine={false}
+            tick={false}
+          />
+          <Tooltip 
+            labelFormatter={formatTooltipLabel}
+            contentStyle={{
+              backgroundColor: "hsl(var(--popover))",
+              border: "1px solid hsl(var(--border))",
+              borderRadius: "6px",
+              fontSize: "12px",
+            }}
+            formatter={(value: number, name: string) => [
+              value,
+              name === "completed" ? "Completed" : "Failed"
+            ]}
+          />
+          <Line
+            type="monotone"
+            dataKey="completed"
+            stroke="#10b981"
+            strokeWidth={1.5}
+            dot={false}
+            activeDot={{ r: 2, stroke: "#10b981", strokeWidth: 1 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="failed"
+            stroke="#ef4444"
+            strokeWidth={1.5}
+            dot={false}
+            activeDot={{ r: 2, stroke: "#ef4444", strokeWidth: 1 }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/apps/app/src/app/queues/_components/queues-table.tsx
+++ b/apps/app/src/app/queues/_components/queues-table.tsx
@@ -30,7 +30,7 @@ export function QueuesTable() {
   }>({
     cursor: null,
     search: "",
-    timePeriod: "1",
+    timePeriod: "30",
   });
 
   const handleQueueClick = (queueName: string) => {
@@ -74,19 +74,19 @@ export function QueuesTable() {
       <Table className="table-fixed w-full">
         <TableHeader>
           <TableRow>
-            <TableHead style={{ width: "260px" }}>Queue Name</TableHead>
+            <TableHead style={{ width: "200px" }}>Queue Name</TableHead>
             <TableHead style={{ width: "120px" }}>Status</TableHead>
             <TableHead style={{ width: "120px" }}>Scheduler</TableHead>
             <TableHead style={{ width: "120px" }}>Active Jobs</TableHead>
             <TableHead style={{ width: "120px" }}>Failed Jobs</TableHead>
             <TableHead style={{ width: "120px" }}>Completed Jobs</TableHead>
-            <TableHead style={{ width: "150px" }}>Trend</TableHead>
-            <TableHead style={{ width: "60px" }}></TableHead>
+            <TableHead style={{ width: "70px" }}>Trend</TableHead>
+            <TableHead style={{ width: "90px" }}></TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {data?.queues.map((queue) => (
-            <TableRow 
+            <TableRow
               key={queue.name}
               className="cursor-pointer hover:bg-muted/50"
               onClick={() => handleQueueClick(queue.name)}
@@ -125,10 +125,7 @@ export function QueuesTable() {
                 </span>
               </TableCell>
               <TableCell onClick={(e) => e.stopPropagation()}>
-                <QueueMiniChart 
-                  data={queue.chartData} 
-                  timePeriod={options.timePeriod}
-                />
+                <QueueMiniChart data={queue.chartData} />
               </TableCell>
               <TableCell onClick={(e) => e.stopPropagation()}>
                 <QueueActions

--- a/apps/app/src/app/queues/_components/queues-table.tsx
+++ b/apps/app/src/app/queues/_components/queues-table.tsx
@@ -18,6 +18,7 @@ import {
 } from "~/components/ui/table";
 import { apiFetch, cn } from "~/lib/utils/client";
 import { QueueActions } from "./queue-actions";
+import { QueueMiniChart } from "./queue-mini-chart";
 import { type TimePeriod, TimePeriodSelector } from "./time-period-selector";
 
 export function QueuesTable() {
@@ -79,6 +80,7 @@ export function QueuesTable() {
             <TableHead style={{ width: "120px" }}>Active Jobs</TableHead>
             <TableHead style={{ width: "120px" }}>Failed Jobs</TableHead>
             <TableHead style={{ width: "120px" }}>Completed Jobs</TableHead>
+            <TableHead style={{ width: "150px" }}>Trend</TableHead>
             <TableHead style={{ width: "60px" }}></TableHead>
           </TableRow>
         </TableHeader>
@@ -121,6 +123,12 @@ export function QueuesTable() {
                 <span className="font-mono text-green-600">
                   {queue.completedJobs}
                 </span>
+              </TableCell>
+              <TableCell onClick={(e) => e.stopPropagation()}>
+                <QueueMiniChart 
+                  data={queue.chartData} 
+                  timePeriod={options.timePeriod}
+                />
               </TableCell>
               <TableCell onClick={(e) => e.stopPropagation()}>
                 <QueueActions

--- a/package-lock.json
+++ b/package-lock.json
@@ -3942,6 +3942,7 @@
       "dependencies": {
         "@clickhouse/client": "^1.12.1",
         "@rharkor/logger": "^1.3.3",
+        "date-fns": "^4.1.0",
         "dotenv": "^17.0.0",
         "tsdown": "^0.15.2",
         "typescript": "^5.9.2",

--- a/packages/clickhouse/package.json
+++ b/packages/clickhouse/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@clickhouse/client": "^1.12.1",
     "@rharkor/logger": "^1.3.3",
+    "date-fns": "^4.1.0",
     "dotenv": "^17.0.0",
     "tsdown": "^0.15.2",
     "typescript": "^5.9.2",

--- a/packages/clickhouse/src/crud/job-stats.ts
+++ b/packages/clickhouse/src/crud/job-stats.ts
@@ -1,5 +1,5 @@
 import { clickhouseClient } from "../lib/client";
-import type { JobStats } from "./schemas";
+import type { JobStats, QueueStatsWithChart } from "./schemas";
 
 export const getJobStats = async ({
   dateFrom,
@@ -61,5 +61,97 @@ export const getJobStats = async ({
   } catch (error) {
     console.error("Error fetching job stats:", error);
     throw new Error("Failed to fetch job statistics");
+  }
+};
+
+export const getQueueStatsWithChart = async ({
+  queueNames,
+  dateFrom,
+  dateTo,
+  timePeriod,
+}: {
+  queueNames: string[];
+  dateFrom: Date;
+  dateTo: Date;
+  timePeriod: number;
+}): Promise<QueueStatsWithChart[]> => {
+  if (queueNames.length === 0) {
+    return [];
+  }
+
+  try {
+    // Determine interval based on time period
+    let interval: string;
+    if (timePeriod <= 1) {
+      interval = "toStartOfHour(created_at)"; // hourly for 1 day
+    } else if (timePeriod <= 7) {
+      interval = "toStartOfHour(created_at)"; // hourly for up to 7 days
+    } else {
+      interval = "toStartOfDay(created_at)"; // daily for longer periods
+    }
+
+    // Get stats for each queue
+    const statsPromises = queueNames.map(async (queueName) => {
+      // Get current counts
+      const countQuery = `
+        SELECT 
+          countIf(status = 'active') as active_jobs,
+          countIf(status = 'failed' AND created_at BETWEEN {date_from:DateTime64(3, 'UTC')} AND {date_to:DateTime64(3, 'UTC')}) as failed_jobs,
+          countIf(status = 'completed' AND created_at BETWEEN {date_from:DateTime64(3, 'UTC')} AND {date_to:DateTime64(3, 'UTC')}) as completed_jobs
+        FROM job_runs_ch 
+        WHERE queue = {queue:String}
+      `;
+
+      // Get chart data
+      const chartQuery = `
+        SELECT 
+          ${interval} as timestamp,
+          countIf(status = 'completed') as completed,
+          countIf(status = 'failed') as failed
+        FROM job_runs_ch 
+        WHERE queue = {queue:String}
+          AND created_at BETWEEN {date_from:DateTime64(3, 'UTC')} AND {date_to:DateTime64(3, 'UTC')}
+        GROUP BY timestamp
+        ORDER BY timestamp
+      `;
+
+      const [countResult, chartResult] = await Promise.all([
+        clickhouseClient.query({
+          query: countQuery,
+          query_params: { queue: queueName, date_from: dateFrom, date_to: dateTo },
+          format: "JSONEachRow",
+        }),
+        clickhouseClient.query({
+          query: chartQuery,
+          query_params: { queue: queueName, date_from: dateFrom, date_to: dateTo },
+          format: "JSONEachRow",
+        }),
+      ]);
+
+      const [countData, chartData] = await Promise.all([
+        countResult.json(),
+        chartResult.json(),
+      ]);
+
+      const counts = countData[0] as { active_jobs: string; failed_jobs: string; completed_jobs: string } || 
+        { active_jobs: "0", failed_jobs: "0", completed_jobs: "0" };
+
+      return {
+        queueName,
+        activeJobs: Number(counts.active_jobs),
+        failedJobs: Number(counts.failed_jobs),
+        completedJobs: Number(counts.completed_jobs),
+        chartData: (chartData as { timestamp: string; completed: string; failed: string }[]).map((item) => ({
+          timestamp: item.timestamp,
+          completed: Number(item.completed),
+          failed: Number(item.failed),
+        })),
+      };
+    });
+
+    return await Promise.all(statsPromises);
+  } catch (error) {
+    console.error("Error fetching queue stats with chart:", error);
+    throw new Error("Failed to fetch queue statistics with chart data");
   }
 };

--- a/packages/clickhouse/src/crud/schemas.ts
+++ b/packages/clickhouse/src/crud/schemas.ts
@@ -42,3 +42,17 @@ export interface JobStats {
   failed: number;
   completed: number;
 }
+
+export interface QueueChartData {
+  timestamp: string;
+  completed: number;
+  failed: number;
+}
+
+export interface QueueStatsWithChart {
+  queueName: string;
+  activeJobs: number;
+  failedJobs: number;
+  completedJobs: number;
+  chartData: QueueChartData[];
+}


### PR DESCRIPTION
Add a job run trend chart column to the queues table and migrate job run statistics fetching from Postgres to ClickHouse.

This change leverages ClickHouse for job run statistics and time-series data, which is better suited for analytical queries than Postgres. This improves performance and scalability for fetching job run counts (active, failed, completed) and the historical data needed for the new trend charts.

---
<a href="https://cursor.com/background-agent?bcId=bc-170e751c-5762-4630-b833-049cc5d24bd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-170e751c-5762-4630-b833-049cc5d24bd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

