### PR TITLE
Add run actions to runs table

### DIFF
--- a/apps/app/src/app/api/jobs/cancel/route.ts
+++ b/apps/app/src/app/api/jobs/cancel/route.ts
@@ -1,0 +1,37 @@
+import { cancelJob } from "@better-bull-board/client/lib/cancellation";
+import { logger } from "@rharkor/logger";
+import { redis } from "~/lib/redis";
+import { createAuthenticatedApiRoute } from "~/lib/utils/server";
+import { cancelJobApiRoute } from "./schemas";
+
+export const POST = createAuthenticatedApiRoute({
+  apiRoute: cancelJobApiRoute,
+  async handler(input) {
+    const { jobId, queueName } = input;
+
+    try {
+      await cancelJob({
+        redis,
+        jobId,
+        queueName,
+      });
+
+      logger.debug(`Job ${jobId} in queue ${queueName} cancelled successfully`);
+
+      return {
+        success: true,
+        message: `Job ${jobId} has been cancelled successfully`,
+      };
+    } catch (error) {
+      logger.error(`Failed to cancel job ${jobId}`, {
+        error: error instanceof Error ? error.message : "Unknown error",
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
+      return {
+        success: false,
+        message: `Failed to cancel job ${jobId}: ${error instanceof Error ? error.message : "Unknown error"}`,
+      };
+    }
+  },
+});

--- a/apps/app/src/app/api/jobs/cancel/schemas.ts
+++ b/apps/app/src/app/api/jobs/cancel/schemas.ts
@@ -1,0 +1,19 @@
+import z from "zod";
+import { registerApiRoute } from "~/lib/utils/client";
+
+export const cancelJobInput = z.object({
+  jobId: z.string(),
+  queueName: z.string(),
+});
+
+export const cancelJobOutput = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});
+
+export const cancelJobApiRoute = registerApiRoute({
+  route: "/api/jobs/cancel",
+  method: "POST",
+  inputSchema: cancelJobInput,
+  outputSchema: cancelJobOutput,
+});

--- a/apps/app/src/app/api/jobs/replay/route.ts
+++ b/apps/app/src/app/api/jobs/replay/route.ts
@@ -1,0 +1,56 @@
+import { logger } from "@rharkor/logger";
+import { Queue } from "bullmq";
+import { redis } from "~/lib/redis";
+import { createAuthenticatedApiRoute } from "~/lib/utils/server";
+import { replayJobApiRoute } from "./schemas";
+
+export const POST = createAuthenticatedApiRoute({
+  apiRoute: replayJobApiRoute,
+  async handler(input) {
+    const { jobId, queueName } = input;
+
+    try {
+      const queue = new Queue(queueName, { connection: redis });
+      const job = await queue.getJob(jobId);
+
+      if (!job) {
+        return {
+          success: false,
+          message: `Job ${jobId} not found in queue ${queueName}`,
+        };
+      }
+
+      // Create a new job with the same data and options as the original
+      const newJob = await queue.add(job.name || "job", job.data, {
+        priority: job.opts.priority,
+        delay: job.opts.delay,
+        attempts: job.opts.attempts,
+        backoff: job.opts.backoff,
+        removeOnComplete: job.opts.removeOnComplete,
+        removeOnFail: job.opts.removeOnFail,
+      });
+
+      logger.debug(`Job ${jobId} replayed successfully as ${newJob.id}`, {
+        originalJobId: jobId,
+        newJobId: newJob.id,
+        queueName,
+      });
+
+      return {
+        success: true,
+        message: `Job ${jobId} has been replayed successfully`,
+        newJobId: newJob.id,
+      };
+    } catch (error) {
+      logger.error(`Failed to replay job ${jobId}`, {
+        error: error instanceof Error ? error.message : "Unknown error",
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
+      return {
+        success: false,
+        message: `Failed to replay job ${jobId}: ${error instanceof Error ? error.message : "Unknown error"}`,
+      };
+    }
+  },
+});

--- a/apps/app/src/app/api/jobs/replay/schemas.ts
+++ b/apps/app/src/app/api/jobs/replay/schemas.ts
@@ -1,0 +1,20 @@
+import z from "zod";
+import { registerApiRoute } from "~/lib/utils/client";
+
+export const replayJobInput = z.object({
+  jobId: z.string(),
+  queueName: z.string(),
+});
+
+export const replayJobOutput = z.object({
+  success: z.boolean(),
+  message: z.string(),
+  newJobId: z.string().optional(),
+});
+
+export const replayJobApiRoute = registerApiRoute({
+  route: "/api/jobs/replay",
+  method: "POST",
+  inputSchema: replayJobInput,
+  outputSchema: replayJobOutput,
+});

--- a/apps/app/src/app/runs/_components/run-actions.tsx
+++ b/apps/app/src/app/runs/_components/run-actions.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { RotateCcw, X } from "lucide-react";
+import { useState } from "react";
+import { cancelJobApiRoute } from "~/app/api/jobs/cancel/schemas";
+import { replayJobApiRoute } from "~/app/api/jobs/replay/schemas";
+import { Button } from "~/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+import { apiFetch } from "~/lib/utils/client";
+
+interface RunActionsProps {
+  jobId: string;
+  queueName: string;
+  status: string;
+}
+
+export function RunActions({ jobId, queueName, status }: RunActionsProps) {
+  const [cancelPopoverOpen, setCancelPopoverOpen] = useState(false);
+  const [replayPopoverOpen, setReplayPopoverOpen] = useState(false);
+  const queryClient = useQueryClient();
+
+  const cancelMutation = useMutation({
+    mutationFn: apiFetch({
+      apiRoute: cancelJobApiRoute,
+      body: { jobId, queueName },
+    }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["jobs/table"] });
+      setCancelPopoverOpen(false);
+    },
+  });
+
+  const replayMutation = useMutation({
+    mutationFn: apiFetch({
+      apiRoute: replayJobApiRoute,
+      body: { jobId, queueName },
+    }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["jobs/table"] });
+      setReplayPopoverOpen(false);
+    },
+  });
+
+  const handleCancel = () => {
+    cancelMutation.mutate();
+  };
+
+  const handleReplay = () => {
+    replayMutation.mutate();
+  };
+
+  const canCancel = status === "active" || status === "waiting" || status === "delayed";
+  const canReplay = status === "completed" || status === "failed";
+
+  if (!canCancel && !canReplay) {
+    return null;
+  }
+
+  return (
+    <div className="flex gap-1">
+      {/* Cancel Button - only show for active, waiting, or delayed jobs */}
+      {canCancel && (
+        <Popover open={cancelPopoverOpen} onOpenChange={setCancelPopoverOpen}>
+          <PopoverTrigger asChild>
+            <Button 
+              variant="ghost" 
+              size="sm"
+              className="text-red-600 hover:text-red-700"
+            >
+              <X className="size-4" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-80">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <h4 className="font-medium leading-none text-red-600">
+                  Cancel Job
+                </h4>
+                <p className="text-sm text-muted-foreground">
+                  Are you sure you want to cancel this job? This action cannot be undone.
+                </p>
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCancelPopoverOpen(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={handleCancel}
+                  disabled={cancelMutation.isPending}
+                >
+                  Cancel Job
+                </Button>
+              </div>
+            </div>
+          </PopoverContent>
+        </Popover>
+      )}
+
+      {/* Replay Button - only show for completed or failed jobs */}
+      {canReplay && (
+        <Popover open={replayPopoverOpen} onOpenChange={setReplayPopoverOpen}>
+          <PopoverTrigger asChild>
+            <Button variant="ghost" size="sm">
+              <RotateCcw className="size-4" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-80">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <h4 className="font-medium leading-none">
+                  Replay Job
+                </h4>
+                <p className="text-sm text-muted-foreground">
+                  Are you sure you want to replay this job? This will create a new job with the same data and configuration.
+                </p>
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setReplayPopoverOpen(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleReplay}
+                  disabled={replayMutation.isPending}
+                >
+                  Replay Job
+                </Button>
+              </div>
+            </div>
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}

--- a/apps/app/src/app/runs/_components/runs-table.tsx
+++ b/apps/app/src/app/runs/_components/runs-table.tsx
@@ -15,6 +15,7 @@ import {
 } from "~/components/ui/table";
 import useDebounce from "~/hooks/use-debounce";
 import { apiFetch, cn } from "~/lib/utils/client";
+import { RunActions } from "./run-actions";
 import { RunsFilters } from "./runs-filters";
 import type { TRunFilters } from "./types";
 
@@ -78,6 +79,7 @@ export function RunsTable({ searchParams }: RunsTableProps) {
             <TableHead style={{ width: "140px" }}>Worker</TableHead>
             <TableHead style={{ width: "160px" }}>Created</TableHead>
             <TableHead style={{ width: "140px" }}>Error</TableHead>
+            <TableHead style={{ width: "80px" }}>Actions</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -123,6 +125,13 @@ export function RunsTable({ searchParams }: RunsTableProps) {
                 })}
               >
                 {run.error_message || "-"}
+              </TableCell>
+              <TableCell onClick={(e) => e.stopPropagation()}>
+                <RunActions
+                  jobId={run.job_id}
+                  queueName={run.queue}
+                  status={run.status}
+                />
               </TableCell>
             </TableRow>
           ))}


### PR DESCRIPTION
Add an action column to the runs table to enable canceling active/waiting/delayed runs and replaying completed/failed runs.

This PR introduces new API routes (`/api/jobs/cancel` and `/api/jobs/replay`) and a `RunActions` component to provide job management functionality directly from the runs table, mirroring the actions available in the queues table. The cancel functionality utilizes the custom `cancelJob` function as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-22b0cdbd-ce1a-422f-a43e-aa983bc32960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-22b0cdbd-ce1a-422f-a43e-aa983bc32960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

