### PR TITLE
Show row actions on hover

### DIFF
--- a/apps/app/src/app/queues/_components/queues-table.tsx
+++ b/apps/app/src/app/queues/_components/queues-table.tsx
@@ -87,7 +87,7 @@ export function QueuesTable() {
             {data?.queues.map((queue) => (
               <motion.tr
                 key={queue.name}
-                className="border-b transition-colors cursor-pointer hover:bg-muted/50 data-[state=selected]:bg-muted"
+                className="group border-b transition-colors cursor-pointer hover:bg-muted/50 data-[state=selected]:bg-muted"
                 onClick={() => handleQueueClick(queue.name)}
                 initial={{ opacity: 0, y: -10 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -132,10 +132,12 @@ export function QueuesTable() {
                   <QueueMiniChart data={queue.chartData} />
                 </TableCell>
                 <TableCell onClick={(e) => e.stopPropagation()}>
-                  <QueueActions
-                    queueName={queue.name}
-                    isPaused={queue.isPaused}
-                  />
+                  <div className="opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                    <QueueActions
+                      queueName={queue.name}
+                      isPaused={queue.isPaused}
+                    />
+                  </div>
                 </TableCell>
               </motion.tr>
             ))}

--- a/apps/app/src/app/runs/_components/runs-table.tsx
+++ b/apps/app/src/app/runs/_components/runs-table.tsx
@@ -81,7 +81,7 @@ export function RunsTable() {
             {runs?.jobs.map((run) => (
               <motion.tr
                 key={run.id}
-                className="border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted"
+                className="group border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted"
                 initial={{ opacity: 0, y: -10 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -10 }}
@@ -134,11 +134,13 @@ export function RunsTable() {
                     : "-"}
                 </TableCell>
                 <TableCell onClick={(e) => e.stopPropagation()}>
-                  <RunActions
-                    jobId={run.job_id}
-                    queueName={run.queue}
-                    status={run.status}
-                  />
+                  <div className="opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                    <RunActions
+                      jobId={run.job_id}
+                      queueName={run.queue}
+                      status={run.status}
+                    />
+                  </div>
                 </TableCell>
               </motion.tr>
             ))}


### PR DESCRIPTION
Hide table row actions by default and show them only on hover to reduce visual clutter.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f5f6dfa-6408-4716-9b47-50127cb48411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f5f6dfa-6408-4716-9b47-50127cb48411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

