### PR TITLE
Add table cursor navigation to frontend

### DIFF
--- a/apps/app/src/app/api/jobs/table/route.ts
+++ b/apps/app/src/app/api/jobs/table/route.ts
@@ -5,11 +5,12 @@ import { getJobsTableApiRoute } from "./schemas";
 export const POST = createAuthenticatedApiRoute({
   apiRoute: getJobsTableApiRoute,
   async handler(input) {
-    const { cursor, search, limit, queue, status } = input;
+    const { cursor, direction, search, limit, queue, status } = input;
 
     const jobs = await searchJobRuns({
       limit,
-      offset: cursor ? Number(cursor) : 0,
+      cursor,
+      direction,
       search,
       queue: queue === "all" ? undefined : queue,
       status: status === "all" ? undefined : status,
@@ -18,6 +19,7 @@ export const POST = createAuthenticatedApiRoute({
     return {
       jobs,
       nextCursor: jobs.length ? (jobs[jobs.length - 1]?.id ?? null) : null,
+      prevCursor: jobs.length ? (jobs[0]?.id ?? null) : null,
     };
   },
 });

--- a/apps/app/src/app/api/jobs/table/route.ts
+++ b/apps/app/src/app/api/jobs/table/route.ts
@@ -5,21 +5,47 @@ import { getJobsTableApiRoute } from "./schemas";
 export const POST = createAuthenticatedApiRoute({
   apiRoute: getJobsTableApiRoute,
   async handler(input) {
-    const { cursor, direction, search, limit, queue, status } = input;
+    const { cursor, search, queue, status } = input;
+    const limit = input.limit ?? 20;
 
     const jobs = await searchJobRuns({
-      limit,
+      limit: limit + 1,
       cursor,
-      direction,
+      direction: "next",
       search,
       queue: queue === "all" ? undefined : queue,
       status: status === "all" ? undefined : status,
     });
 
+    const previousJobs = cursor
+      ? await searchJobRuns({
+          limit: limit + 1,
+          cursor,
+          direction: "prev",
+          search,
+          queue: queue === "all" ? undefined : queue,
+          status: status === "all" ? undefined : status,
+        })
+      : [];
+
+    const nextCursor =
+      jobs.length > limit ? (jobs.pop()?.created_at ?? null) : null;
+    const prevCursor =
+      previousJobs.length > limit
+        ? // Since we are in desc order we need to shift not pop
+          (previousJobs.shift()?.created_at ?? null)
+        : null;
+
     return {
-      jobs,
-      nextCursor: jobs.length ? (jobs[jobs.length - 1]?.id ?? null) : null,
-      prevCursor: jobs.length ? (jobs[0]?.id ?? null) : null,
+      jobs: jobs.map((job) => ({
+        ...job,
+        created_at: new Date(job.created_at),
+        enqueued_at: job.enqueued_at ? new Date(job.enqueued_at) : null,
+        started_at: job.started_at ? new Date(job.started_at) : null,
+        finished_at: job.finished_at ? new Date(job.finished_at) : null,
+      })),
+      nextCursor,
+      prevCursor,
     };
   },
 });

--- a/apps/app/src/app/api/jobs/table/schemas.ts
+++ b/apps/app/src/app/api/jobs/table/schemas.ts
@@ -4,6 +4,7 @@ import { registerApiRoute } from "~/lib/utils/client";
 
 export const getJobsTableInput = z.object({
   cursor: z.string().nullish(),
+  direction: z.enum(['next', 'prev']).optional().default('next'),
   search: z.string().optional(),
   status: z.string().optional(),
   queue: z.string().optional(),
@@ -13,6 +14,7 @@ export const getJobsTableInput = z.object({
 export const getJobsTableOutput = z.object({
   jobs: z.array(jobRunDataSchema),
   nextCursor: z.string().nullable(),
+  prevCursor: z.string().nullable(),
 });
 
 export const getJobsTableApiRoute = registerApiRoute({

--- a/apps/app/src/app/api/jobs/table/schemas.ts
+++ b/apps/app/src/app/api/jobs/table/schemas.ts
@@ -3,8 +3,7 @@ import z from "zod";
 import { registerApiRoute } from "~/lib/utils/client";
 
 export const getJobsTableInput = z.object({
-  cursor: z.string().nullish(),
-  direction: z.enum(['next', 'prev']).optional().default('next'),
+  cursor: z.number().nullish(),
   search: z.string().optional(),
   status: z.string().optional(),
   queue: z.string().optional(),
@@ -13,8 +12,8 @@ export const getJobsTableInput = z.object({
 
 export const getJobsTableOutput = z.object({
   jobs: z.array(jobRunDataSchema),
-  nextCursor: z.string().nullable(),
-  prevCursor: z.string().nullable(),
+  nextCursor: z.number().nullable(),
+  prevCursor: z.number().nullable(),
 });
 
 export const getJobsTableApiRoute = registerApiRoute({

--- a/apps/app/src/app/api/queues/table/route.ts
+++ b/apps/app/src/app/api/queues/table/route.ts
@@ -1,41 +1,49 @@
 import { getQueueStatsWithChart } from "@better-bull-board/clickhouse";
 import { jobSchedulersTable, queuesTable } from "@better-bull-board/db";
 import { db } from "@better-bull-board/db/server";
-import { and, eq, gt, lt, ilike, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, ilike, lte, sql } from "drizzle-orm";
 import { createAuthenticatedApiRoute } from "~/lib/utils/server";
 import { getQueuesTableApiRoute } from "./schemas";
 
 export const POST = createAuthenticatedApiRoute({
   apiRoute: getQueuesTableApiRoute,
   async handler(input) {
-    const { cursor, direction, search, timePeriod, limit } = input;
+    const { cursor, search, timePeriod } = input;
+    const limit = input.limit ?? 20;
+
+    const getRows = async (direction: "next" | "prev") => {
+      return db
+        .select({
+          id: queuesTable.id,
+          name: queuesTable.name,
+          isPaused: queuesTable.isPaused,
+          pattern: jobSchedulersTable.pattern,
+          every: jobSchedulersTable.every,
+        })
+        .from(queuesTable)
+        .leftJoin(
+          jobSchedulersTable,
+          eq(jobSchedulersTable.queueId, queuesTable.id),
+        )
+        .where(
+          and(
+            cursor
+              ? direction === "prev"
+                ? lte(queuesTable.name, cursor)
+                : gte(queuesTable.name, cursor)
+              : undefined,
+            search ? ilike(queuesTable.name, `%${search}%`) : undefined,
+          ),
+        )
+        .orderBy(
+          direction === "prev" ? desc(queuesTable.name) : asc(queuesTable.name),
+        )
+        .limit(limit + 1);
+    };
 
     // Get queue info from Postgres (basic queue data)
-    const rows = await db
-      .select({
-        id: queuesTable.id,
-        name: queuesTable.name,
-        isPaused: queuesTable.isPaused,
-        pattern: jobSchedulersTable.pattern,
-        every: jobSchedulersTable.every,
-      })
-      .from(queuesTable)
-      .leftJoin(
-        jobSchedulersTable,
-        eq(jobSchedulersTable.queueId, queuesTable.id),
-      )
-      .where(
-        and(
-          cursor 
-            ? direction === 'prev' 
-              ? lt(queuesTable.id, cursor)
-              : gt(queuesTable.id, cursor)
-            : undefined,
-          search ? ilike(queuesTable.name, `%${search}%`) : undefined,
-        ),
-      )
-      .orderBy(direction === 'prev' ? sql`${queuesTable.id} DESC` : queuesTable.id)
-      .limit(limit ?? 20);
+    const rows = await getRows("next");
+    const previousRows = cursor ? await getRows("prev") : [];
 
     const [total] = await db
       .select({ count: sql<number>`COUNT(*)` })
@@ -60,11 +68,12 @@ export const POST = createAuthenticatedApiRoute({
     // Create a map for quick lookup
     const statsMap = new Map(queueStats.map((stat) => [stat.queueName, stat]));
 
-    // If we got results in reverse order (prev direction), reverse them back to normal order
-    const orderedRows = direction === 'prev' ? rows.reverse() : rows;
+    const nextCursor = rows.length > limit ? (rows.pop()?.name ?? null) : null;
+    const prevCursor =
+      previousRows.length > limit ? (previousRows.pop()?.name ?? null) : null;
 
     return {
-      queues: orderedRows.map((row) => {
+      queues: rows.map((row) => {
         const stats = statsMap.get(row.name) ?? {
           queueName: row.name,
           activeJobs: 0,
@@ -84,8 +93,8 @@ export const POST = createAuthenticatedApiRoute({
           chartData: stats.chartData,
         };
       }),
-      nextCursor: orderedRows.length ? (orderedRows[orderedRows.length - 1]?.id ?? null) : null,
-      prevCursor: orderedRows.length ? (orderedRows[0]?.id ?? null) : null,
+      nextCursor,
+      prevCursor,
       total: Number(total?.count ?? 0),
     };
   },

--- a/apps/app/src/app/api/queues/table/schemas.ts
+++ b/apps/app/src/app/api/queues/table/schemas.ts
@@ -3,7 +3,6 @@ import { registerApiRoute } from "~/lib/utils/client";
 
 export const getQueuesTableInput = z.object({
   cursor: z.string().nullish(),
-  direction: z.enum(['next', 'prev']).optional().default('next'),
   search: z.string().optional(),
   timePeriod: z.enum(["1", "3", "7", "30"]).optional().default("1"),
   limit: z.number().min(1).max(100).optional(),

--- a/apps/app/src/app/api/queues/table/schemas.ts
+++ b/apps/app/src/app/api/queues/table/schemas.ts
@@ -3,6 +3,7 @@ import { registerApiRoute } from "~/lib/utils/client";
 
 export const getQueuesTableInput = z.object({
   cursor: z.string().nullish(),
+  direction: z.enum(['next', 'prev']).optional().default('next'),
   search: z.string().optional(),
   timePeriod: z.enum(["1", "3", "7", "30"]).optional().default("1"),
   limit: z.number().min(1).max(100).optional(),
@@ -28,6 +29,7 @@ export const getQueuesTableOutput = z.object({
     }),
   ),
   nextCursor: z.string().nullable(),
+  prevCursor: z.string().nullable(),
   total: z.number(),
 });
 

--- a/apps/app/src/app/queues/_components/queues-table.tsx
+++ b/apps/app/src/app/queues/_components/queues-table.tsx
@@ -58,6 +58,8 @@ export function QueuesTable() {
   const handlePrevPage = () => {
     if (data?.prevCursor) {
       setUrlState({ cursor: data.prevCursor });
+    } else {
+      setUrlState({ cursor: null });
     }
   };
 
@@ -94,7 +96,7 @@ export function QueuesTable() {
             variant="outline"
             size="sm"
             onClick={handlePrevPage}
-            disabled={isLoading || !data?.prevCursor}
+            disabled={isLoading || (!data?.prevCursor && !options.cursor)}
           >
             <ChevronLeft className="h-4 w-4" />
             Previous

--- a/apps/app/src/app/runs/_components/runs-filters.tsx
+++ b/apps/app/src/app/runs/_components/runs-filters.tsx
@@ -125,6 +125,8 @@ export function RunsFilters({
   const handlePrevPage = () => {
     if (runs?.prevCursor) {
       setFilters({ cursor: runs.prevCursor });
+    } else {
+      setFilters({ cursor: null });
     }
   };
 
@@ -223,7 +225,7 @@ export function RunsFilters({
           variant="outline"
           size="sm"
           onClick={handlePrevPage}
-          disabled={isLoading || !runs?.prevCursor}
+          disabled={isLoading || (!runs?.prevCursor && !filters.cursor)}
         >
           <ChevronLeft className="h-4 w-4" />
           Previous

--- a/apps/app/src/app/runs/_components/runs-filters.tsx
+++ b/apps/app/src/app/runs/_components/runs-filters.tsx
@@ -197,7 +197,7 @@ export function RunsFilters({
             </div>
           </PopoverContent>
         </Popover>
-        <div className="flex-1 relative max-w-[350px]">
+        <div className="flex-1 relative w-[350px]">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
             placeholder="Search by job ID, name, or error..."

--- a/apps/app/src/app/runs/_components/runs-filters.tsx
+++ b/apps/app/src/app/runs/_components/runs-filters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { Filter, Search, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, Filter, Search, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { getQueuesTableApiRoute } from "~/app/api/queues/table/schemas";
 import { Badge } from "~/components/ui/badge";
@@ -19,11 +19,18 @@ import type { TRunFilters } from "./types";
 export function RunsFilters({
   filters,
   setFilters,
+  runs,
 }: {
   filters: TRunFilters;
   setFilters: (
-    filters: Partial<Pick<TRunFilters, "queue" | "status" | "search">>,
+    filters: Partial<
+      Pick<TRunFilters, "queue" | "status" | "search" | "cursor">
+    >,
   ) => void;
+  runs?: {
+    nextCursor: number | null;
+    prevCursor: number | null;
+  };
 }) {
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [queueOpen, setQueueOpen] = useState(false);
@@ -36,7 +43,11 @@ export function RunsFilters({
     queryFn: ({ pageParam }: { pageParam: string | null }) =>
       apiFetch({
         apiRoute: getQueuesTableApiRoute,
-        body: { search: queueSearch, cursor: pageParam, timePeriod: "1" },
+        body: {
+          search: queueSearch,
+          cursor: pageParam,
+          timePeriod: "1",
+        },
       })(),
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     initialPageParam: null,
@@ -97,98 +108,136 @@ export function RunsFilters({
 
   const removeFilter = (filterKey: string) => {
     setFilters({
+      cursor: null,
       [filterKey]: filterKey === "queue" || filterKey === "status" ? "all" : "",
     });
   };
 
   const activeFilters = getActiveFilters();
 
+  //* Pagination
+  const handleNextPage = () => {
+    if (runs?.nextCursor) {
+      setFilters({ cursor: runs.nextCursor });
+    }
+  };
+
+  const handlePrevPage = () => {
+    if (runs?.prevCursor) {
+      setFilters({ cursor: runs.prevCursor });
+    }
+  };
+
   return (
-    <div className="flex items-center gap-2">
-      <Popover open={filtersOpen} onOpenChange={setFiltersOpen}>
-        <PopoverTrigger asChild>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-9 gap-1 bg-transparent"
-          >
-            <Filter className="h-4 w-4" />
-            Filters
-            {activeFilters.length > 0 && (
-              <Badge variant="secondary" className="ml-1 h-5 min-w-5 text-xs">
-                {activeFilters.length}
-              </Badge>
-            )}
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-80 p-4" align="end">
-          <div className="space-y-4">
-            <div className="font-medium text-sm">Filter Options</div>
+    <div className="flex items-center justify-between gap-2">
+      <div className="flex items-center gap-2">
+        <Popover open={filtersOpen} onOpenChange={setFiltersOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 gap-1 bg-transparent"
+            >
+              <Filter className="h-4 w-4" />
+              Filters
+              {activeFilters.length > 0 && (
+                <Badge variant="secondary" className="ml-1 h-5 min-w-5 text-xs">
+                  {activeFilters.length}
+                </Badge>
+              )}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-80 p-4" align="end">
+            <div className="space-y-4">
+              <div className="font-medium text-sm">Filter Options</div>
 
-            <div className="space-y-3">
-              <div>
-                <label className="text-sm font-medium mb-2 block">Queue</label>
-                <Combobox
-                  value={filters.queue}
-                  onValueChange={(value) => setFilters({ queue: value })}
-                  options={queueOptions}
-                  placeholder="All Queues"
-                  noOptionsMessage="No queues found"
-                  searchPlaceholder="Search queues..."
-                  search={queueSearch}
-                  setSearch={setQueueSearch}
-                  open={queueOpen}
-                  setOpen={setQueueOpen}
-                  renderValue={renderQueueValue}
-                  className="w-full"
-                />
-              </div>
-
-              <div>
-                <label className="text-sm font-medium mb-2 block">
-                  Status
+              <div className="space-y-3">
+                <div>
+                  <label className="text-sm font-medium mb-2 block">
+                    Queue
+                  </label>
                   <Combobox
-                    value={filters.status}
-                    onValueChange={(value) => setFilters({ status: value })}
-                    options={statusOptions}
-                    placeholder="All Statuses"
-                    noOptionsMessage="No statuses found"
-                    searchPlaceholder="Search statuses..."
-                    search={statusSearch}
-                    setSearch={setStatusSearch}
-                    open={statusOpen}
-                    setOpen={setStatusOpen}
-                    renderValue={renderStatusValue}
+                    value={filters.queue}
+                    onValueChange={(value) => setFilters({ queue: value })}
+                    options={queueOptions}
+                    placeholder="All Queues"
+                    noOptionsMessage="No queues found"
+                    searchPlaceholder="Search queues..."
+                    search={queueSearch}
+                    setSearch={setQueueSearch}
+                    open={queueOpen}
+                    setOpen={setQueueOpen}
+                    renderValue={renderQueueValue}
                     className="w-full"
                   />
-                </label>
+                </div>
+
+                <div>
+                  <label className="text-sm font-medium mb-2 block">
+                    Status
+                    <Combobox
+                      value={filters.status}
+                      onValueChange={(value) => setFilters({ status: value })}
+                      options={statusOptions}
+                      placeholder="All Statuses"
+                      noOptionsMessage="No statuses found"
+                      searchPlaceholder="Search statuses..."
+                      search={statusSearch}
+                      setSearch={setStatusSearch}
+                      open={statusOpen}
+                      setOpen={setStatusOpen}
+                      renderValue={renderStatusValue}
+                      className="w-full"
+                    />
+                  </label>
+                </div>
               </div>
             </div>
-          </div>
-        </PopoverContent>
-      </Popover>
-      <div className="flex-1 relative max-w-[350px]">
-        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-        <Input
-          placeholder="Search by job ID, name, or error..."
-          value={filters.search}
-          onChange={(e) => setFilters({ search: e.target.value })}
-          className="pl-10"
-        />
+          </PopoverContent>
+        </Popover>
+        <div className="flex-1 relative max-w-[350px]">
+          <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search by job ID, name, or error..."
+            value={filters.search}
+            onChange={(e) => setFilters({ search: e.target.value })}
+            className="pl-10"
+          />
+        </div>
+        {activeFilters.map((filter) => (
+          <Badge key={filter.key} variant="secondary" className="h-9 px-2">
+            {filter.label}
+            <Button
+              variant="ghost"
+              size="sm"
+              className="size-4 p-0 hover:bg-transparent"
+              onClick={() => removeFilter(filter.key)}
+            >
+              <X className="size-3" />
+            </Button>
+          </Badge>
+        ))}
       </div>
-      {activeFilters.map((filter) => (
-        <Badge key={filter.key} variant="secondary" className="h-9 px-2">
-          {filter.label}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="size-4 p-0 hover:bg-transparent"
-            onClick={() => removeFilter(filter.key)}
-          >
-            <X className="size-3" />
-          </Button>
-        </Badge>
-      ))}
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handlePrevPage}
+          disabled={isLoading || !runs?.prevCursor}
+        >
+          <ChevronLeft className="h-4 w-4" />
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleNextPage}
+          disabled={isLoading || !runs?.nextCursor}
+        >
+          Next
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/app/src/app/runs/_components/runs-table.tsx
+++ b/apps/app/src/app/runs/_components/runs-table.tsx
@@ -31,7 +31,7 @@ export function RunsTable() {
   const filters: TRunFilters = {
     ...urlFilters,
     cursor: urlFilters.cursor ?? null,
-    limit: 1,
+    limit: 15,
   };
   const debouncedFilters = useDebounce(filters, 300);
 

--- a/apps/app/src/app/runs/_components/types.ts
+++ b/apps/app/src/app/runs/_components/types.ts
@@ -3,5 +3,6 @@ export type TRunFilters = {
   status: string;
   search: string;
   cursor: string | null;
+  direction?: 'next' | 'prev';
   limit: number;
 };

--- a/apps/app/src/app/runs/_components/types.ts
+++ b/apps/app/src/app/runs/_components/types.ts
@@ -2,7 +2,6 @@ export type TRunFilters = {
   queue: string;
   status: string;
   search: string;
-  cursor: string | null;
-  direction?: 'next' | 'prev';
+  cursor: number | null;
   limit: number;
 };

--- a/packages/bull-demo/src/demo2/queue.ts
+++ b/packages/bull-demo/src/demo2/queue.ts
@@ -5,6 +5,18 @@ export const queue = new Queue("demo-queue-2", {
   connection: redis,
 });
 
+export const queue3 = new Queue("demo-queue-3", {
+  connection: redis,
+});
+
+export const queue4 = new Queue("demo-queue-4", {
+  connection: redis,
+});
+
+export const queue5 = new Queue("demo-queue-5", {
+  connection: redis,
+});
+
 export const registerScheduler = async () => {
   await queue.upsertJobScheduler("demo-queue-2", {
     every: 20_000,

--- a/packages/bull-demo/src/worker.ts
+++ b/packages/bull-demo/src/worker.ts
@@ -26,3 +26,30 @@ new Worker("demo-queue-2", processorFile2, {
     return ["demo-queue-2"];
   },
 });
+
+new Worker("demo-queue-3", processorFile2, {
+  connection: redis,
+  ioredis: redis,
+  useWorkerThreads: true,
+  concurrency: 10,
+  getJobTags() {
+    return ["demo-queue-3"];
+  },
+});
+
+new Worker("demo-queue-4", processorFile2, {
+  connection: redis,
+  ioredis: redis,
+  useWorkerThreads: true,
+  concurrency: 10,
+  getJobTags() {
+    return ["demo-queue-4"];
+  },
+});
+
+new Worker("demo-queue-5", processorFile2, {
+  connection: redis,
+  ioredis: redis,
+  useWorkerThreads: true,
+  concurrency: 10,
+});

--- a/turbo.json
+++ b/turbo.json
@@ -7,6 +7,7 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
+    "type-check": {},
     "lint": {
       "dependsOn": ["^lint"]
     },


### PR DESCRIPTION
Add bidirectional cursor-based pagination to Runs and Queues tables.

The existing backend only supported forward pagination. This PR extends the backend to handle reverse queries (`id < cursor` with `ORDER BY ASC` and result reversal) and updates the frontend to manage cursor history for `Previous` button functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-e20337c6-03fd-4aee-9ce3-2e60425ff107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e20337c6-03fd-4aee-9ce3-2e60425ff107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

