### PR TITLE
Bulk job selection and action

### DIFF
--- a/apps/app/src/app/api/jobs/bulk-cancel/route.ts
+++ b/apps/app/src/app/api/jobs/bulk-cancel/route.ts
@@ -1,0 +1,73 @@
+import { cancelJobRun } from "@better-bull-board/clickhouse";
+import { cancelJob } from "@better-bull-board/client/lib/cancellation";
+import { jobRunsTable } from "@better-bull-board/db";
+import { db } from "@better-bull-board/db/server";
+import { eq } from "drizzle-orm";
+import { redis } from "~/lib/redis";
+import { createAuthenticatedApiRoute } from "~/lib/utils/server";
+import { bulkCancelJobsApiRoute } from "./schemas";
+
+export const POST = createAuthenticatedApiRoute({
+  apiRoute: bulkCancelJobsApiRoute,
+  async handler(input) {
+    const { jobs } = input;
+
+    const results = [];
+    let cancelled = 0;
+    let failed = 0;
+
+    for (const { jobId, queueName } of jobs) {
+      try {
+        await cancelJob({
+          redis,
+          jobId,
+          queueName,
+        });
+
+        // Sometimes the job doesn't exist anymore in redis so we need to ensure that it was really cancelled
+        await db.transaction(async (tx) => {
+          const [pgjob] = await db
+            .select()
+            .from(jobRunsTable)
+            .where(eq(jobRunsTable.jobId, jobId))
+            .limit(1);
+          
+          if (!pgjob) {
+            throw new Error(`Job ${jobId} not found`);
+          }
+
+          if (pgjob.status !== "completed" && pgjob.status !== "failed") {
+            await tx
+              .update(jobRunsTable)
+              .set({
+                status: "failed",
+                errorMessage: "Job cancelled",
+              })
+              .where(eq(jobRunsTable.jobId, jobId));
+
+            // Clickhouse
+            await cancelJobRun(jobId);
+          }
+        });
+
+        results.push({ jobId, success: true });
+        cancelled++;
+      } catch (error) {
+        results.push({ 
+          jobId, 
+          success: false, 
+          error: error instanceof Error ? error.message : 'Unknown error'
+        });
+        failed++;
+      }
+    }
+
+    return {
+      success: true,
+      message: `Bulk operation completed: ${cancelled} cancelled, ${failed} failed`,
+      cancelled,
+      failed,
+      results,
+    };
+  },
+});

--- a/apps/app/src/app/api/jobs/bulk-cancel/schemas.ts
+++ b/apps/app/src/app/api/jobs/bulk-cancel/schemas.ts
@@ -1,0 +1,28 @@
+import z from "zod";
+import { registerApiRoute } from "~/lib/utils/client";
+
+export const bulkCancelJobsInput = z.object({
+  jobs: z.array(z.object({
+    jobId: z.string(),
+    queueName: z.string(),
+  })),
+});
+
+export const bulkCancelJobsOutput = z.object({
+  success: z.boolean(),
+  message: z.string(),
+  cancelled: z.number(),
+  failed: z.number(),
+  results: z.array(z.object({
+    jobId: z.string(),
+    success: z.boolean(),
+    error: z.string().optional(),
+  })),
+});
+
+export const bulkCancelJobsApiRoute = registerApiRoute({
+  route: "/api/jobs/bulk-cancel",
+  method: "POST",
+  inputSchema: bulkCancelJobsInput,
+  outputSchema: bulkCancelJobsOutput,
+});

--- a/apps/app/src/app/api/jobs/bulk-retry/route.ts
+++ b/apps/app/src/app/api/jobs/bulk-retry/route.ts
@@ -1,0 +1,57 @@
+import { Queue } from "bullmq";
+import { redis } from "~/lib/redis";
+import { createAuthenticatedApiRoute } from "~/lib/utils/server";
+import { bulkRetryJobsApiRoute } from "./schemas";
+
+export const POST = createAuthenticatedApiRoute({
+  apiRoute: bulkRetryJobsApiRoute,
+  async handler(input) {
+    const { jobs } = input;
+
+    const results = [];
+    let retried = 0;
+    let failed = 0;
+
+    // Group jobs by queue for efficiency
+    const jobsByQueue = jobs.reduce((acc, job) => {
+      if (!acc[job.queueName]) {
+        acc[job.queueName] = [];
+      }
+      acc[job.queueName]!.push(job.jobId);
+      return acc;
+    }, {} as Record<string, string[]>);
+
+    for (const [queueName, jobIds] of Object.entries(jobsByQueue)) {
+      const queue = new Queue(queueName, { connection: redis });
+
+      for (const jobId of jobIds) {
+        try {
+          const job = await queue.getJob(jobId);
+
+          if (!job) {
+            throw new Error("Job not found");
+          }
+
+          await job.retry();
+          results.push({ jobId, success: true });
+          retried++;
+        } catch (error) {
+          results.push({ 
+            jobId, 
+            success: false, 
+            error: error instanceof Error ? error.message : 'Unknown error'
+          });
+          failed++;
+        }
+      }
+    }
+
+    return {
+      success: true,
+      message: `Bulk operation completed: ${retried} retried, ${failed} failed`,
+      retried,
+      failed,
+      results,
+    };
+  },
+});

--- a/apps/app/src/app/api/jobs/bulk-retry/schemas.ts
+++ b/apps/app/src/app/api/jobs/bulk-retry/schemas.ts
@@ -1,0 +1,28 @@
+import z from "zod";
+import { registerApiRoute } from "~/lib/utils/client";
+
+export const bulkRetryJobsInput = z.object({
+  jobs: z.array(z.object({
+    jobId: z.string(),
+    queueName: z.string(),
+  })),
+});
+
+export const bulkRetryJobsOutput = z.object({
+  success: z.boolean(),
+  message: z.string(),
+  retried: z.number(),
+  failed: z.number(),
+  results: z.array(z.object({
+    jobId: z.string(),
+    success: z.boolean(),
+    error: z.string().optional(),
+  })),
+});
+
+export const bulkRetryJobsApiRoute = registerApiRoute({
+  route: "/api/jobs/bulk-retry",
+  method: "POST",
+  inputSchema: bulkRetryJobsInput,
+  outputSchema: bulkRetryJobsOutput,
+});

--- a/apps/app/src/app/runs/_components/bulk-actions.tsx
+++ b/apps/app/src/app/runs/_components/bulk-actions.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { RotateCcw, X, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { bulkCancelJobsApiRoute } from "~/app/api/jobs/bulk-cancel/schemas";
+import { bulkRetryJobsApiRoute } from "~/app/api/jobs/bulk-retry/schemas";
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { Badge } from "~/components/ui/badge";
+import { apiFetch } from "~/lib/utils/client";
+
+interface BulkActionsProps {
+  selectedJobs: Array<{
+    job_id: string;
+    queue: string;
+    status: string;
+  }>;
+  onClearSelection: () => void;
+}
+
+export function BulkActions({ selectedJobs, onClearSelection }: BulkActionsProps) {
+  const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
+  const [retryDialogOpen, setRetryDialogOpen] = useState(false);
+  const queryClient = useQueryClient();
+
+  const bulkCancelMutation = useMutation({
+    mutationFn: apiFetch({
+      apiRoute: bulkCancelJobsApiRoute,
+      body: {
+        jobs: selectedJobs.map(job => ({
+          jobId: job.job_id,
+          queueName: job.queue,
+        })),
+      },
+    }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["jobs/table"] });
+      setCancelDialogOpen(false);
+      onClearSelection();
+    },
+  });
+
+  const bulkRetryMutation = useMutation({
+    mutationFn: apiFetch({
+      apiRoute: bulkRetryJobsApiRoute,
+      body: {
+        jobs: selectedJobs.map(job => ({
+          jobId: job.job_id,
+          queueName: job.queue,
+        })),
+      },
+    }),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["jobs/table"] });
+      setRetryDialogOpen(false);
+      onClearSelection();
+    },
+  });
+
+  const handleBulkCancel = () => {
+    bulkCancelMutation.mutate();
+  };
+
+  const handleBulkRetry = () => {
+    bulkRetryMutation.mutate();
+  };
+
+  // Filter jobs that can be cancelled
+  const cancellableJobs = selectedJobs.filter(job => 
+    job.status === "active" || job.status === "waiting" || job.status === "delayed"
+  );
+
+  // Filter jobs that can be retried
+  const retryableJobs = selectedJobs.filter(job => 
+    job.status === "completed" || job.status === "failed"
+  );
+
+  if (selectedJobs.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="flex items-center gap-4 p-4 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg">
+        <div className="flex items-center gap-2">
+          <Badge variant="secondary">
+            {selectedJobs.length} job{selectedJobs.length === 1 ? '' : 's'} selected
+          </Badge>
+          {cancellableJobs.length > 0 && (
+            <Badge variant="outline" className="text-red-600">
+              {cancellableJobs.length} cancellable
+            </Badge>
+          )}
+          {retryableJobs.length > 0 && (
+            <Badge variant="outline" className="text-green-600">
+              {retryableJobs.length} retryable
+            </Badge>
+          )}
+        </div>
+        
+        <div className="flex items-center gap-2">
+          {cancellableJobs.length > 0 && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setCancelDialogOpen(true)}
+              className="flex items-center gap-2"
+            >
+              <X className="size-4" />
+              Cancel ({cancellableJobs.length})
+            </Button>
+          )}
+          
+          {retryableJobs.length > 0 && (
+            <Button
+              variant="default"
+              size="sm"
+              onClick={() => setRetryDialogOpen(true)}
+              className="flex items-center gap-2"
+            >
+              <RotateCcw className="size-4" />
+              Retry ({retryableJobs.length})
+            </Button>
+          )}
+          
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onClearSelection}
+            className="flex items-center gap-2"
+          >
+            <Trash2 className="size-4" />
+            Clear Selection
+          </Button>
+        </div>
+      </div>
+
+      {/* Cancel Confirmation Dialog */}
+      <Dialog open={cancelDialogOpen} onOpenChange={setCancelDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="text-red-600">Cancel Jobs</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to cancel {cancellableJobs.length} job{cancellableJobs.length === 1 ? '' : 's'}? 
+              This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="max-h-60 overflow-y-auto">
+            <div className="space-y-2">
+              {cancellableJobs.map((job) => (
+                <div key={job.job_id} className="flex items-center gap-2 p-2 bg-gray-50 dark:bg-gray-800 rounded">
+                  <Badge variant="outline">{job.queue}</Badge>
+                  <span className="font-mono text-xs">{job.job_id.slice(0, 20)}...</span>
+                  <Badge className="ml-auto">{job.status}</Badge>
+                </div>
+              ))}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCancelDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleBulkCancel}
+              disabled={bulkCancelMutation.isPending}
+            >
+              {bulkCancelMutation.isPending ? "Cancelling..." : "Cancel Jobs"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Retry Confirmation Dialog */}
+      <Dialog open={retryDialogOpen} onOpenChange={setRetryDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Retry Jobs</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to retry {retryableJobs.length} job{retryableJobs.length === 1 ? '' : 's'}? 
+              This will create new job instances with the same data and configuration.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="max-h-60 overflow-y-auto">
+            <div className="space-y-2">
+              {retryableJobs.map((job) => (
+                <div key={job.job_id} className="flex items-center gap-2 p-2 bg-gray-50 dark:bg-gray-800 rounded">
+                  <Badge variant="outline">{job.queue}</Badge>
+                  <span className="font-mono text-xs">{job.job_id.slice(0, 20)}...</span>
+                  <Badge className="ml-auto">{job.status}</Badge>
+                </div>
+              ))}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRetryDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleBulkRetry}
+              disabled={bulkRetryMutation.isPending}
+            >
+              {bulkRetryMutation.isPending ? "Retrying..." : "Retry Jobs"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/app/src/app/runs/_components/runs-table.tsx
+++ b/apps/app/src/app/runs/_components/runs-table.tsx
@@ -4,8 +4,10 @@ import { useQuery } from "@tanstack/react-query";
 import { formatDistanceStrict, formatDistanceToNow } from "date-fns";
 import { AnimatePresence, motion } from "framer-motion";
 import { useQueryStates, parseAsString } from "nuqs";
+import { useState, useMemo, useEffect } from "react";
 import { getJobsTableApiRoute } from "~/app/api/jobs/table/schemas";
 import { Badge } from "~/components/ui/badge";
+import { Checkbox } from "~/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -16,6 +18,7 @@ import {
 } from "~/components/ui/table";
 import useDebounce from "~/hooks/use-debounce";
 import { apiFetch, cn } from "~/lib/utils/client";
+import { BulkActions } from "./bulk-actions";
 import { RunActions } from "./run-actions";
 import { RunsFilters } from "./runs-filters";
 import type { TRunFilters } from "./types";
@@ -26,6 +29,8 @@ export function RunsTable() {
     status: parseAsString.withDefault("all"),
     search: parseAsString.withDefault(""),
   });
+
+  const [selectedJobIds, setSelectedJobIds] = useState<Set<string>>(new Set());
 
   const filters: TRunFilters = {
     ...urlFilters,
@@ -41,6 +46,38 @@ export function RunsTable() {
       body: debouncedFilters,
     }),
   });
+
+  const jobs = runs?.jobs || [];
+  
+  // Clear selection when filters change
+  useEffect(() => {
+    setSelectedJobIds(new Set());
+  }, [debouncedFilters]);
+  
+  const selectedJobs = useMemo(() => {
+    return jobs.filter(job => selectedJobIds.has(job.job_id));
+  }, [jobs, selectedJobIds]);
+
+  const handleSelectAll = (checked: boolean) => {
+    if (checked) {
+      setSelectedJobIds(new Set(jobs.map(job => job.job_id)));
+    } else {
+      setSelectedJobIds(new Set());
+    }
+  };
+
+  const handleSelectJob = (jobId: string, checked: boolean) => {
+    const newSelection = new Set(selectedJobIds);
+    if (checked) {
+      newSelection.add(jobId);
+    } else {
+      newSelection.delete(jobId);
+    }
+    setSelectedJobIds(newSelection);
+  };
+
+  const isAllSelected = jobs.length > 0 && selectedJobIds.size === jobs.length;
+  const isPartiallySelected = selectedJobIds.size > 0 && selectedJobIds.size < jobs.length;
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -62,9 +99,25 @@ export function RunsTable() {
   return (
     <div className="space-y-4">
       <RunsFilters filters={filters} setFilters={setUrlFilters} />
+      
+      {selectedJobs.length > 0 && (
+        <BulkActions 
+          selectedJobs={selectedJobs} 
+          onClearSelection={() => setSelectedJobIds(new Set())}
+        />
+      )}
+      
       <Table className="table-fixed w-full">
         <TableHeader>
           <TableRow>
+            <TableHead style={{ width: "50px" }}>
+              <Checkbox
+                checked={isAllSelected}
+                indeterminate={isPartiallySelected}
+                onCheckedChange={handleSelectAll}
+                aria-label="Select all jobs"
+              />
+            </TableHead>
             <TableHead style={{ width: "260px" }}>Job ID</TableHead>
             <TableHead style={{ width: "120px" }}>Queue</TableHead>
             <TableHead style={{ width: "180px" }}>Tags</TableHead>
@@ -78,16 +131,28 @@ export function RunsTable() {
         </TableHeader>
         <TableBody>
           <AnimatePresence mode="popLayout">
-            {runs?.jobs.map((run) => (
+            {jobs.map((run) => (
               <motion.tr
                 key={run.id}
-                className="group border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted"
+                className={cn(
+                  "group border-b transition-colors hover:bg-muted/50",
+                  selectedJobIds.has(run.job_id) && "bg-blue-50 dark:bg-blue-950"
+                )}
                 initial={{ opacity: 0, y: -10 }}
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -10 }}
                 transition={{ duration: 0.2 }}
                 layout
               >
+                <TableCell>
+                  <Checkbox
+                    checked={selectedJobIds.has(run.job_id)}
+                    onCheckedChange={(checked) => 
+                      handleSelectJob(run.job_id, checked as boolean)
+                    }
+                    aria-label={`Select job ${run.job_id}`}
+                  />
+                </TableCell>
                 <TableCell className="font-mono text-xs">
                   {run.job_id.slice(0, 32)}
                   {run.job_id.length > 32 && "..."}

--- a/apps/app/src/components/ui/checkbox.tsx
+++ b/apps/app/src/components/ui/checkbox.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import * as React from "react";
+import { Check, Minus } from "lucide-react";
+import { cn } from "~/lib/utils/client";
+
+interface CheckboxProps {
+  checked?: boolean;
+  indeterminate?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+  className?: string;
+  "aria-label"?: string;
+}
+
+const Checkbox = React.forwardRef<HTMLButtonElement, CheckboxProps>(
+  ({ checked = false, indeterminate = false, onCheckedChange, className, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="checkbox"
+        aria-checked={indeterminate ? "mixed" : checked}
+        onClick={() => onCheckedChange?.(!checked)}
+        className={cn(
+          "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          checked || indeterminate
+            ? "bg-primary text-primary-foreground"
+            : "bg-background",
+          className
+        )}
+        {...props}
+      >
+        {indeterminate ? (
+          <Minus className="h-3 w-3" />
+        ) : checked ? (
+          <Check className="h-3 w-3" />
+        ) : null}
+      </button>
+    );
+  }
+);
+
+Checkbox.displayName = "Checkbox";
+
+export { Checkbox };


### PR DESCRIPTION
Add bulk selection and actions (cancel/retry) to the runs page to enable efficient management of multiple jobs.

---
<a href="https://cursor.com/background-agent?bcId=bc-60e47ac6-7637-43fa-80ee-25a39c68141b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-60e47ac6-7637-43fa-80ee-25a39c68141b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

