### PR TITLE
Add tag filtering to runs

### DIFF
--- a/apps/app/src/app/api/jobs/table/route.ts
+++ b/apps/app/src/app/api/jobs/table/route.ts
@@ -5,7 +5,7 @@ import { getJobsTableApiRoute } from "./schemas";
 export const POST = createAuthenticatedApiRoute({
   apiRoute: getJobsTableApiRoute,
   async handler(input) {
-    const { cursor, search, queue, status } = input;
+    const { cursor, search, queue, status, tags } = input;
     const limit = input.limit ?? 20;
 
     const jobs = await searchJobRuns({
@@ -15,6 +15,7 @@ export const POST = createAuthenticatedApiRoute({
       search,
       queue: queue === "all" ? undefined : queue,
       status: status === "all" ? undefined : status,
+      tags: tags && tags.length > 0 ? tags : undefined,
     });
 
     const previousJobs = cursor
@@ -25,6 +26,7 @@ export const POST = createAuthenticatedApiRoute({
           search,
           queue: queue === "all" ? undefined : queue,
           status: status === "all" ? undefined : status,
+          tags: tags && tags.length > 0 ? tags : undefined,
         })
       : [];
 

--- a/apps/app/src/app/api/jobs/table/schemas.ts
+++ b/apps/app/src/app/api/jobs/table/schemas.ts
@@ -7,6 +7,7 @@ export const getJobsTableInput = z.object({
   search: z.string().optional(),
   status: z.string().optional(),
   queue: z.string().optional(),
+  tags: z.array(z.string()).optional(),
   limit: z.number().min(1).max(100).optional(),
 });
 

--- a/apps/app/src/app/api/tags/route.ts
+++ b/apps/app/src/app/api/tags/route.ts
@@ -1,0 +1,34 @@
+import { clickhouseClient } from "@better-bull-board/clickhouse/lib/client";
+import { createAuthenticatedApiRoute } from "~/lib/utils/server";
+import { getTagsApiRoute } from "./schemas";
+
+export const POST = createAuthenticatedApiRoute({
+  apiRoute: getTagsApiRoute,
+  async handler(input) {
+    const { search } = input;
+
+    // Query to get distinct tags from job runs
+    const query = `
+      SELECT DISTINCT arrayJoin(tags) as tag
+      FROM job_runs 
+      WHERE tag != ''
+      ${search ? "AND tag ILIKE {search:String}" : ""}
+      ORDER BY tag
+      LIMIT 100
+    `;
+
+    const params = search ? { search: `%${search}%` } : {};
+    
+    const result = await clickhouseClient.query({
+      query,
+      query_params: params,
+      format: "JSONEachRow",
+    });
+
+    const tags = await result.json<{ tag: string }[]>();
+    
+    return {
+      tags: tags.map(row => row.tag),
+    };
+  },
+});

--- a/apps/app/src/app/api/tags/route.ts
+++ b/apps/app/src/app/api/tags/route.ts
@@ -1,4 +1,4 @@
-import { clickhouseClient } from "@better-bull-board/clickhouse/lib/client";
+import { clickhouseClient } from "@better-bull-board/clickhouse/client";
 import { createAuthenticatedApiRoute } from "~/lib/utils/server";
 import { getTagsApiRoute } from "./schemas";
 
@@ -10,7 +10,7 @@ export const POST = createAuthenticatedApiRoute({
     // Query to get distinct tags from job runs
     const query = `
       SELECT DISTINCT arrayJoin(tags) as tag
-      FROM job_runs 
+      FROM job_runs_ch 
       WHERE tag != ''
       ${search ? "AND tag ILIKE {search:String}" : ""}
       ORDER BY tag
@@ -18,17 +18,17 @@ export const POST = createAuthenticatedApiRoute({
     `;
 
     const params = search ? { search: `%${search}%` } : {};
-    
+
     const result = await clickhouseClient.query({
       query,
       query_params: params,
       format: "JSONEachRow",
     });
 
-    const tags = await result.json<{ tag: string }[]>();
-    
+    const tags = await result.json<{ tag: string }>();
+
     return {
-      tags: tags.map(row => row.tag),
+      tags: tags.map((row) => row.tag),
     };
   },
 });

--- a/apps/app/src/app/api/tags/schemas.ts
+++ b/apps/app/src/app/api/tags/schemas.ts
@@ -1,0 +1,17 @@
+import z from "zod";
+import { registerApiRoute } from "~/lib/utils/client";
+
+export const getTagsInput = z.object({
+  search: z.string().optional(),
+});
+
+export const getTagsOutput = z.object({
+  tags: z.array(z.string()),
+});
+
+export const getTagsApiRoute = registerApiRoute({
+  route: "/api/tags",
+  method: "POST",
+  inputSchema: getTagsInput,
+  outputSchema: getTagsOutput,
+});

--- a/apps/app/src/app/runs/_components/runs-filters.tsx
+++ b/apps/app/src/app/runs/_components/runs-filters.tsx
@@ -47,6 +47,7 @@ export function RunsFilters({
   const {
     data: queues,
     isLoading,
+    isFetching: isQueuesFetching,
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
@@ -73,7 +74,7 @@ export function RunsFilters({
     enabled: queueOpen,
   });
 
-  const { data: tagsData } = useQuery({
+  const { data: tagsData, isFetching: isTagsFetching } = useQuery({
     queryKey: ["tags", tagsSearch],
     queryFn: apiFetch({
       apiRoute: getTagsApiRoute,
@@ -118,7 +119,6 @@ export function RunsFilters({
     return option ? option.label : "All Statuses";
   };
 
-
   const getActiveFilters = () => {
     const activeFilters = [];
 
@@ -161,7 +161,12 @@ export function RunsFilters({
     } else {
       setFilters({
         cursor: null,
-        [filterKey]: filterKey === "queue" || filterKey === "status" ? "all" : filterKey === "tags" ? [] : "",
+        [filterKey]:
+          filterKey === "queue" || filterKey === "status"
+            ? "all"
+            : filterKey === "tags"
+              ? []
+              : "",
       });
     }
   };
@@ -224,6 +229,7 @@ export function RunsFilters({
                     setOpen={setQueueOpen}
                     renderValue={renderQueueValue}
                     className="w-full"
+                    isFetching={isQueuesFetching}
                     infiniteLoadingProps={{
                       hasNextPage,
                       fetchNextPage,
@@ -254,21 +260,25 @@ export function RunsFilters({
                 </div>
 
                 <div>
-                  <label className="text-sm font-medium mb-2 block">
-                    Tags
-                  </label>
+                  <label className="text-sm font-medium mb-2 block">Tags</label>
                   <div className="space-y-2">
                     {filters.tags.length > 0 && (
                       <div className="flex flex-wrap gap-1">
                         {filters.tags.map((tag) => (
-                          <Badge key={tag} variant="secondary" className="text-xs">
+                          <Badge
+                            key={tag}
+                            variant="secondary"
+                            className="text-xs"
+                          >
                             {tag}
                             <Button
                               variant="ghost"
                               size="sm"
                               className="size-3 p-0 ml-1 hover:bg-transparent"
                               onClick={() => {
-                                const newTags = filters.tags.filter((t) => t !== tag);
+                                const newTags = filters.tags.filter(
+                                  (t) => t !== tag,
+                                );
                                 setFilters({ tags: newTags });
                               }}
                             >
@@ -286,7 +296,9 @@ export function RunsFilters({
                         }
                         setTagsSearch("");
                       }}
-                      options={tagsOptions.filter((option) => !filters.tags.includes(option.value))}
+                      options={tagsOptions.filter(
+                        (option) => !filters.tags.includes(option.value),
+                      )}
                       placeholder="Add tags..."
                       noOptionsMessage="No tags found"
                       searchPlaceholder="Search tags..."
@@ -296,6 +308,7 @@ export function RunsFilters({
                       setOpen={setTagsOpen}
                       renderValue={() => ""}
                       className="w-full"
+                      isFetching={isTagsFetching}
                     />
                   </div>
                 </div>
@@ -313,7 +326,11 @@ export function RunsFilters({
           />
         </div>
         {activeFilters.map((filter, index) => (
-          <Badge key={`${filter.key}-${index}`} variant="secondary" className="h-9 px-2">
+          <Badge
+            key={`${filter.key}-${index}`}
+            variant="secondary"
+            className="h-9 px-2"
+          >
             {filter.label}
             <Button
               variant="ghost"

--- a/apps/app/src/app/runs/_components/runs-table.tsx
+++ b/apps/app/src/app/runs/_components/runs-table.tsx
@@ -30,6 +30,7 @@ export function RunsTable() {
     queue: parseAsString.withDefault("all"),
     status: parseAsString.withDefault("all"),
     search: parseAsString.withDefault(""),
+    tags: parseAsString.withDefault(""),
     cursor: parseAsInteger,
   });
 
@@ -37,6 +38,7 @@ export function RunsTable() {
 
   const filters: TRunFilters = {
     ...urlFilters,
+    tags: urlFilters.tags ? urlFilters.tags.split(",").filter(Boolean) : [],
     cursor: urlFilters.cursor ?? null,
     limit: 15,
   };
@@ -49,6 +51,24 @@ export function RunsTable() {
       body: debouncedFilters,
     }),
   });
+
+  const handleFiltersChange = (
+    newFilters: Partial<
+      Pick<TRunFilters, "queue" | "status" | "search" | "tags" | "cursor">
+    >,
+  ) => {
+    const urlUpdate: Record<string, any> = {};
+    
+    for (const [key, value] of Object.entries(newFilters)) {
+      if (key === "tags" && Array.isArray(value)) {
+        urlUpdate[key] = value.length > 0 ? value.join(",") : "";
+      } else {
+        urlUpdate[key] = value;
+      }
+    }
+    
+    setUrlFilters(urlUpdate);
+  };
 
   const jobs = runs?.jobs || [];
 
@@ -108,7 +128,7 @@ export function RunsTable() {
     <div className="space-y-4">
       <RunsFilters
         filters={filters}
-        setFilters={setUrlFilters}
+        setFilters={handleFiltersChange}
         runs={runs}
         startEndContent={
           selectedJobs.length > 0 && (

--- a/apps/app/src/app/runs/_components/types.ts
+++ b/apps/app/src/app/runs/_components/types.ts
@@ -2,6 +2,7 @@ export type TRunFilters = {
   queue: string;
   status: string;
   search: string;
+  tags: string[];
   cursor: number | null;
   limit: number;
 };

--- a/packages/clickhouse/package.json
+++ b/packages/clickhouse/package.json
@@ -31,6 +31,11 @@
       "types": "./dist/schemas.d.ts",
       "import": "./dist/schemas.js",
       "require": "./dist/schemas.cjs"
+    },
+    "./client": {
+      "types": "./dist/lib/client.d.ts",
+      "import": "./dist/lib/client.js",
+      "require": "./dist/lib/client.cjs"
     }
   },
   "type": "module"


### PR DESCRIPTION
Adds tag filtering functionality to the runs table to allow users to filter job runs by associated tags.

The implementation includes backend updates to accept tag filters and a new API to fetch available tags, alongside frontend changes to `RunsTable` for URL state management and `RunsFilters` for a tag input with suggestions and dismissible badges. An initial attempt to use a multi-select combobox was revised to a simpler input with suggestions due to the absence of a suitable multi-select component.

---
<a href="https://cursor.com/background-agent?bcId=bc-4053255a-a533-47d0-bd17-83a3cf1df9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4053255a-a533-47d0-bd17-83a3cf1df9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

