### PR TITLE
Display queue performance statistics with time range selection

### DIFF
--- a/apps/app/src/app/_components/enhanced-dashboard.tsx
+++ b/apps/app/src/app/_components/enhanced-dashboard.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+import { TimePeriodSelector, type TimePeriod } from "~/components/time-period-selector";
+import { EnhancedStatsCards } from "./enhanced-stats-cards";
+import { QueuePerformanceTable } from "./queue-performance-table";
+import { QueueDurationChart } from "./queue-duration-chart";
+import { QueueCountChart } from "./queue-count-chart";
+import { RunGraphChart } from "./run-graph-chart";
+
+export function EnhancedDashboard() {
+  const [timePeriod, setTimePeriod] = useState<TimePeriod>("7");
+  const days = parseInt(timePeriod);
+
+  return (
+    <div className="space-y-6">
+      {/* Time Period Selector */}
+      <div className="flex justify-between items-center">
+        <div>
+          <h2 className="text-lg font-semibold">Dashboard Analytics</h2>
+          <p className="text-sm text-muted-foreground">
+            Monitor your BullMQ job performance and queue analytics
+          </p>
+        </div>
+        <TimePeriodSelector value={timePeriod} onChange={setTimePeriod} />
+      </div>
+
+      {/* Enhanced Stats Cards */}
+      <EnhancedStatsCards days={days} />
+
+      {/* Queue Performance Table */}
+      <QueuePerformanceTable days={days} />
+
+      {/* Charts Grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <QueueDurationChart days={days} />
+        <QueueCountChart days={days} />
+      </div>
+
+      {/* Run Graph */}
+      <RunGraphChart days={days} />
+    </div>
+  );
+}

--- a/apps/app/src/app/_components/enhanced-stats-cards.tsx
+++ b/apps/app/src/app/_components/enhanced-stats-cards.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Activity, AlertCircle, CheckCircle, Clock } from "lucide-react";
+import { getEnhancedStatsApiRoute } from "~/app/api/dashboard/enhanced-stats/schemas";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
+import { apiFetch, cn } from "~/lib/utils/client";
+
+interface EnhancedStatsCardsProps {
+  days: number;
+}
+
+export function EnhancedStatsCards({ days }: EnhancedStatsCardsProps) {
+  const { data: stats, isLoading } = useQuery({
+    queryKey: ["dashboard/enhanced-stats", days],
+    queryFn: apiFetch({
+      apiRoute: getEnhancedStatsApiRoute,
+      body: { days },
+    }),
+  });
+
+  const cards = [
+    {
+      title: "Running Tasks",
+      value: stats?.runningTasks,
+      icon: Activity,
+      description: "Currently executing",
+      color: "text-blue-600",
+    },
+    {
+      title: "Waiting in Queue",
+      value: stats?.waitingInQueue,
+      icon: Clock,
+      description: "Queued for execution",
+      color: "text-yellow-600",
+    },
+    {
+      title: "Successes",
+      value: stats?.successes,
+      icon: CheckCircle,
+      description: `Completed in last ${days} day${days > 1 ? "s" : ""}`,
+      color: "text-green-600",
+    },
+    {
+      title: "Failures",
+      value: stats?.failures,
+      icon: AlertCircle,
+      description: `Failed in last ${days} day${days > 1 ? "s" : ""}`,
+      color: "text-red-600",
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+      {cards.map((card) => (
+        <Card key={card.title}>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle className="text-sm font-medium">{card.title}</CardTitle>
+            <card.icon className={cn("size-4", card.color)} />
+          </CardHeader>
+          <CardContent className="space-y-1">
+            {isLoading ? (
+              <Skeleton className="h-8 w-full" />
+            ) : (
+              <div className="text-2xl font-bold font-mono">
+                {card.value?.toLocaleString()}
+              </div>
+            )}
+            <p className="text-xs text-muted-foreground">{card.description}</p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/app/src/app/_components/queue-count-chart.tsx
+++ b/apps/app/src/app/_components/queue-count-chart.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import { getTopQueuesCountApiRoute } from "~/app/api/dashboard/top-queues-count/schemas";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
+import { apiFetch } from "~/lib/utils/client";
+
+interface QueueCountChartProps {
+  days: number;
+}
+
+const COLORS = [
+  "#0088FE",
+  "#00C49F",
+  "#FFBB28",
+  "#FF8042",
+  "#8884D8",
+  "#82CA9D",
+  "#FFC658",
+  "#FF6B6B",
+  "#4ECDC4",
+  "#45B7D1",
+];
+
+export function QueueCountChart({ days }: QueueCountChartProps) {
+  const { data: queueCounts, isLoading } = useQuery({
+    queryKey: ["dashboard/top-queues-count", days],
+    queryFn: apiFetch({
+      apiRoute: getTopQueuesCountApiRoute,
+      body: { days, limit: 10 },
+    }),
+  });
+
+  const chartData = queueCounts?.map((item) => ({
+    name: item.queue,
+    value: item.runCount,
+  })) || [];
+
+  const CustomTooltip = ({ active, payload }: any) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div className="bg-background border rounded-lg p-3 shadow-lg">
+          <p className="font-medium">{data.name}</p>
+          <p className="text-sm text-muted-foreground">
+            Runs: {data.value.toLocaleString()}
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Most-Ran Queues</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="h-80 flex items-center justify-center">
+            <Skeleton className="h-80 w-80 rounded-full" />
+          </div>
+        ) : chartData.length > 0 ? (
+          <div className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={chartData}
+                  cx="50%"
+                  cy="50%"
+                  labelLine={false}
+                  label={(props: any) =>
+                    `${props.name} (${(props.percent * 100).toFixed(0)}%)`
+                  }
+                  outerRadius={80}
+                  fill="#8884d8"
+                  dataKey="value"
+                >
+                  {chartData.map((_, index) => (
+                    <Cell
+                      key={`cell-${index}`}
+                      fill={COLORS[index % COLORS.length]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip content={<CustomTooltip />} />
+              </PieChart>
+            </ResponsiveContainer>
+            <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
+              {chartData.slice(0, 6).map((item, index) => (
+                <div key={item.name} className="flex items-center gap-2">
+                  <div
+                    className="w-3 h-3 rounded-full"
+                    style={{ backgroundColor: COLORS[index % COLORS.length] }}
+                  />
+                  <span className="truncate">{item.name}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="h-80 flex items-center justify-center">
+            <p className="text-muted-foreground">No data available</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/app/src/app/_components/queue-duration-chart.tsx
+++ b/apps/app/src/app/_components/queue-duration-chart.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
+import { getTopQueuesDurationApiRoute } from "~/app/api/dashboard/top-queues-duration/schemas";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
+import { apiFetch } from "~/lib/utils/client";
+
+interface QueueDurationChartProps {
+  days: number;
+}
+
+const COLORS = [
+  "#0088FE",
+  "#00C49F",
+  "#FFBB28",
+  "#FF8042",
+  "#8884D8",
+  "#82CA9D",
+  "#FFC658",
+  "#FF6B6B",
+  "#4ECDC4",
+  "#45B7D1",
+];
+
+export function QueueDurationChart({ days }: QueueDurationChartProps) {
+  const { data: queueDuration, isLoading } = useQuery({
+    queryKey: ["dashboard/top-queues-duration", days],
+    queryFn: apiFetch({
+      apiRoute: getTopQueuesDurationApiRoute,
+      body: { days, limit: 10 },
+    }),
+  });
+
+  const formatDuration = (seconds: number) => {
+    if (seconds < 60) return `${seconds.toFixed(1)}s`;
+    if (seconds < 3600) return `${(seconds / 60).toFixed(1)}m`;
+    return `${(seconds / 3600).toFixed(1)}h`;
+  };
+
+  const chartData = queueDuration?.map((item) => ({
+    name: item.queue,
+    value: item.totalDuration,
+    formattedValue: formatDuration(item.totalDuration),
+  })) || [];
+
+  const CustomTooltip = ({ active, payload }: any) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div className="bg-background border rounded-lg p-3 shadow-lg">
+          <p className="font-medium">{data.name}</p>
+          <p className="text-sm text-muted-foreground">
+            Total Duration: {data.formattedValue}
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Average Duration by Queues</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="h-80 flex items-center justify-center">
+            <Skeleton className="h-80 w-80 rounded-full" />
+          </div>
+        ) : chartData.length > 0 ? (
+          <div className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={chartData}
+                  cx="50%"
+                  cy="50%"
+                  labelLine={false}
+                  label={(props: any) =>
+                    `${props.name} (${(props.percent * 100).toFixed(0)}%)`
+                  }
+                  outerRadius={80}
+                  fill="#8884d8"
+                  dataKey="value"
+                >
+                  {chartData.map((_, index) => (
+                    <Cell
+                      key={`cell-${index}`}
+                      fill={COLORS[index % COLORS.length]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip content={<CustomTooltip />} />
+              </PieChart>
+            </ResponsiveContainer>
+            <div className="mt-4 grid grid-cols-2 gap-2 text-sm">
+              {chartData.slice(0, 6).map((item, index) => (
+                <div key={item.name} className="flex items-center gap-2">
+                  <div
+                    className="w-3 h-3 rounded-full"
+                    style={{ backgroundColor: COLORS[index % COLORS.length] }}
+                  />
+                  <span className="truncate">{item.name}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="h-80 flex items-center justify-center">
+            <p className="text-muted-foreground">No data available</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/app/src/app/_components/queue-performance-table.tsx
+++ b/apps/app/src/app/_components/queue-performance-table.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { getQueuePerformanceApiRoute } from "~/app/api/dashboard/queue-performance/schemas";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/components/ui/table";
+import { apiFetch } from "~/lib/utils/client";
+import { Skeleton } from "~/components/ui/skeleton";
+
+interface QueuePerformanceTableProps {
+  days: number;
+}
+
+export function QueuePerformanceTable({ days }: QueuePerformanceTableProps) {
+  const { data: queuePerformance, isLoading } = useQuery({
+    queryKey: ["dashboard/queue-performance", days],
+    queryFn: apiFetch({
+      apiRoute: getQueuePerformanceApiRoute,
+      body: { days },
+    }),
+  });
+
+  const formatDuration = (seconds: number) => {
+    if (seconds < 60) return `${seconds.toFixed(1)}s`;
+    if (seconds < 3600) return `${(seconds / 60).toFixed(1)}m`;
+    return `${(seconds / 3600).toFixed(1)}h`;
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Queue Performance Summary</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-12 w-full" />
+            ))}
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Queue</TableHead>
+                <TableHead className="text-right">Total Runs</TableHead>
+                <TableHead className="text-right">Success</TableHead>
+                <TableHead className="text-right">Failed</TableHead>
+                <TableHead className="text-right">Error Rate</TableHead>
+                <TableHead className="text-right">Avg Duration</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {queuePerformance?.map((queue) => (
+                <TableRow key={queue.queue}>
+                  <TableCell className="font-medium">{queue.queue}</TableCell>
+                  <TableCell className="text-right font-mono">
+                    {queue.totalRuns.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right font-mono text-green-600">
+                    {queue.successes.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right font-mono text-red-600">
+                    {queue.failures.toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right font-mono">
+                    <span
+                      className={
+                        queue.errorRate > 10
+                          ? "text-red-600"
+                          : queue.errorRate > 5
+                            ? "text-yellow-600"
+                            : "text-green-600"
+                      }
+                    >
+                      {queue.errorRate.toFixed(1)}%
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-right font-mono">
+                    {formatDuration(queue.avgDuration)}
+                  </TableCell>
+                </TableRow>
+              ))}
+              {!queuePerformance?.length && (
+                <TableRow>
+                  <TableCell colSpan={6} className="text-center text-muted-foreground">
+                    No data available for the selected period
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/app/src/app/_components/run-graph-chart.tsx
+++ b/apps/app/src/app/_components/run-graph-chart.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { format } from "date-fns";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { getRunGraphApiRoute } from "~/app/api/dashboard/run-graph/schemas";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Skeleton } from "~/components/ui/skeleton";
+import { apiFetch } from "~/lib/utils/client";
+
+interface RunGraphChartProps {
+  days: number;
+}
+
+export function RunGraphChart({ days }: RunGraphChartProps) {
+  const { data: runGraphData, isLoading } = useQuery({
+    queryKey: ["dashboard/run-graph", days],
+    queryFn: apiFetch({
+      apiRoute: getRunGraphApiRoute,
+      body: { days },
+    }),
+  });
+
+  const chartData = runGraphData?.map((item) => ({
+    timestamp: item.timestamp,
+    runCount: item.runCount,
+    formattedTime: format(new Date(item.timestamp), days <= 1 ? "HH:mm" : "MMM dd"),
+  })) || [];
+
+  const CustomTooltip = ({ active, payload, label }: any) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div className="bg-background border rounded-lg p-3 shadow-lg">
+          <p className="font-medium">
+            {format(new Date(label), days <= 1 ? "HH:mm" : "MMM dd, yyyy")}
+          </p>
+          <p className="text-sm text-blue-600">
+            Runs: {data.runCount.toLocaleString()}
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Run Graph</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="h-80 flex items-center justify-center">
+            <Skeleton className="h-80 w-full" />
+          </div>
+        ) : chartData.length > 0 ? (
+          <div className="h-80">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={chartData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis
+                  dataKey="formattedTime"
+                  tick={{ fontSize: 12 }}
+                  interval="preserveStartEnd"
+                />
+                <YAxis tick={{ fontSize: 12 }} />
+                <Tooltip content={<CustomTooltip />} />
+                <Line
+                  type="monotone"
+                  dataKey="runCount"
+                  stroke="#3b82f6"
+                  strokeWidth={2}
+                  dot={{ r: 4 }}
+                  activeDot={{ r: 6 }}
+                  name="Run Count"
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        ) : (
+          <div className="h-80 flex items-center justify-center">
+            <p className="text-muted-foreground">No data available</p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/app/src/app/api/dashboard/enhanced-stats/route.ts
+++ b/apps/app/src/app/api/dashboard/enhanced-stats/route.ts
@@ -1,0 +1,16 @@
+import { getEnhancedJobStats } from "@better-bull-board/clickhouse";
+import { createAuthenticatedApiRoute } from "~/lib/utils/server";
+import { getEnhancedStatsApiRoute } from "./schemas";
+
+export const POST = createAuthenticatedApiRoute({
+  apiRoute: getEnhancedStatsApiRoute,
+  async handler(input) {
+    const days = input?.days || 1;
+    const stats = await getEnhancedJobStats({
+      dateFrom: new Date(Date.now() - days * 24 * 60 * 60 * 1000),
+      dateTo: new Date(),
+    });
+
+    return stats;
+  },
+});

--- a/apps/app/src/app/api/dashboard/enhanced-stats/schemas.ts
+++ b/apps/app/src/app/api/dashboard/enhanced-stats/schemas.ts
@@ -1,0 +1,20 @@
+import z from "zod";
+import { registerApiRoute } from "~/lib/utils/client";
+
+export const getEnhancedStatsInput = z.object({
+  days: z.number().min(1).max(30),
+});
+
+export const getEnhancedStatsOutput = z.object({
+  runningTasks: z.number(),
+  waitingInQueue: z.number(),
+  successes: z.number(),
+  failures: z.number(),
+});
+
+export const getEnhancedStatsApiRoute = registerApiRoute({
+  route: "/api/dashboard/enhanced-stats",
+  method: "POST",
+  inputSchema: getEnhancedStatsInput,
+  outputSchema: getEnhancedStatsOutput,
+});

--- a/apps/app/src/app/api/dashboard/queue-performance/route.ts
+++ b/apps/app/src/app/api/dashboard/queue-performance/route.ts
@@ -1,0 +1,16 @@
+import { getQueuePerformanceData } from "@better-bull-board/clickhouse";
+import { createAuthenticatedApiRoute } from "~/lib/utils/server";
+import { getQueuePerformanceApiRoute } from "./schemas";
+
+export const POST = createAuthenticatedApiRoute({
+  apiRoute: getQueuePerformanceApiRoute,
+  async handler(input) {
+    const days = input?.days || 1;
+    const data = await getQueuePerformanceData({
+      dateFrom: new Date(Date.now() - days * 24 * 60 * 60 * 1000),
+      dateTo: new Date(),
+    });
+
+    return data;
+  },
+});

--- a/apps/app/src/app/api/dashboard/queue-performance/schemas.ts
+++ b/apps/app/src/app/api/dashboard/queue-performance/schemas.ts
@@ -1,0 +1,24 @@
+import z from "zod";
+import { registerApiRoute } from "~/lib/utils/client";
+
+export const getQueuePerformanceInput = z.object({
+  days: z.number().min(1).max(30),
+});
+
+export const getQueuePerformanceOutput = z.array(
+  z.object({
+    queue: z.string(),
+    totalRuns: z.number(),
+    successes: z.number(),
+    failures: z.number(),
+    errorRate: z.number(),
+    avgDuration: z.number(),
+  }),
+);
+
+export const getQueuePerformanceApiRoute = registerApiRoute({
+  route: "/api/dashboard/queue-performance",
+  method: "POST",
+  inputSchema: getQueuePerformanceInput,
+  outputSchema: getQueuePerformanceOutput,
+});

--- a/apps/app/src/app/api/dashboard/run-graph/route.ts
+++ b/apps/app/src/app/api/dashboard/run-graph/route.ts
@@ -1,0 +1,17 @@
+import { getRunGraphData } from "@better-bull-board/clickhouse";
+import { createAuthenticatedApiRoute } from "~/lib/utils/server";
+import { getRunGraphApiRoute } from "./schemas";
+
+export const POST = createAuthenticatedApiRoute({
+  apiRoute: getRunGraphApiRoute,
+  async handler(input) {
+    const days = input?.days || 1;
+    const data = await getRunGraphData({
+      dateFrom: new Date(Date.now() - days * 24 * 60 * 60 * 1000),
+      dateTo: new Date(),
+      timePeriod: days,
+    });
+
+    return data;
+  },
+});

--- a/apps/app/src/app/api/dashboard/run-graph/schemas.ts
+++ b/apps/app/src/app/api/dashboard/run-graph/schemas.ts
@@ -1,0 +1,20 @@
+import z from "zod";
+import { registerApiRoute } from "~/lib/utils/client";
+
+export const getRunGraphInput = z.object({
+  days: z.number().min(1).max(30),
+});
+
+export const getRunGraphOutput = z.array(
+  z.object({
+    timestamp: z.string(),
+    runCount: z.number(),
+  }),
+);
+
+export const getRunGraphApiRoute = registerApiRoute({
+  route: "/api/dashboard/run-graph",
+  method: "POST",
+  inputSchema: getRunGraphInput,
+  outputSchema: getRunGraphOutput,
+});

--- a/apps/app/src/app/api/dashboard/top-queues-count/route.ts
+++ b/apps/app/src/app/api/dashboard/top-queues-count/route.ts
@@ -1,0 +1,18 @@
+import { getTopQueuesByRunCount } from "@better-bull-board/clickhouse";
+import { createAuthenticatedApiRoute } from "~/lib/utils/server";
+import { getTopQueuesCountApiRoute } from "./schemas";
+
+export const POST = createAuthenticatedApiRoute({
+  apiRoute: getTopQueuesCountApiRoute,
+  async handler(input) {
+    const days = input?.days || 1;
+    const limit = input?.limit || 10;
+    const data = await getTopQueuesByRunCount({
+      dateFrom: new Date(Date.now() - days * 24 * 60 * 60 * 1000),
+      dateTo: new Date(),
+      limit,
+    });
+
+    return data;
+  },
+});

--- a/apps/app/src/app/api/dashboard/top-queues-count/schemas.ts
+++ b/apps/app/src/app/api/dashboard/top-queues-count/schemas.ts
@@ -1,0 +1,21 @@
+import z from "zod";
+import { registerApiRoute } from "~/lib/utils/client";
+
+export const getTopQueuesCountInput = z.object({
+  days: z.number().min(1).max(30),
+  limit: z.number().min(1).max(20).optional().default(10),
+});
+
+export const getTopQueuesCountOutput = z.array(
+  z.object({
+    queue: z.string(),
+    runCount: z.number(),
+  }),
+);
+
+export const getTopQueuesCountApiRoute = registerApiRoute({
+  route: "/api/dashboard/top-queues-count",
+  method: "POST",
+  inputSchema: getTopQueuesCountInput,
+  outputSchema: getTopQueuesCountOutput,
+});

--- a/apps/app/src/app/api/dashboard/top-queues-duration/route.ts
+++ b/apps/app/src/app/api/dashboard/top-queues-duration/route.ts
@@ -1,0 +1,18 @@
+import { getTopQueuesByDuration } from "@better-bull-board/clickhouse";
+import { createAuthenticatedApiRoute } from "~/lib/utils/server";
+import { getTopQueuesDurationApiRoute } from "./schemas";
+
+export const POST = createAuthenticatedApiRoute({
+  apiRoute: getTopQueuesDurationApiRoute,
+  async handler(input) {
+    const days = input?.days || 1;
+    const limit = input?.limit || 10;
+    const data = await getTopQueuesByDuration({
+      dateFrom: new Date(Date.now() - days * 24 * 60 * 60 * 1000),
+      dateTo: new Date(),
+      limit,
+    });
+
+    return data;
+  },
+});

--- a/apps/app/src/app/api/dashboard/top-queues-duration/schemas.ts
+++ b/apps/app/src/app/api/dashboard/top-queues-duration/schemas.ts
@@ -1,0 +1,21 @@
+import z from "zod";
+import { registerApiRoute } from "~/lib/utils/client";
+
+export const getTopQueuesDurationInput = z.object({
+  days: z.number().min(1).max(30),
+  limit: z.number().min(1).max(20).optional().default(10),
+});
+
+export const getTopQueuesDurationOutput = z.array(
+  z.object({
+    queue: z.string(),
+    totalDuration: z.number(),
+  }),
+);
+
+export const getTopQueuesDurationApiRoute = registerApiRoute({
+  route: "/api/dashboard/top-queues-duration",
+  method: "POST",
+  inputSchema: getTopQueuesDurationInput,
+  outputSchema: getTopQueuesDurationOutput,
+});

--- a/apps/app/src/app/page.tsx
+++ b/apps/app/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { StatsCards } from "~/app/_components/stats-card";
+import { EnhancedDashboard } from "~/app/_components/enhanced-dashboard";
 import { PageContainer } from "~/components/page-container";
 import { PageTitle } from "~/components/page-title";
 
@@ -9,7 +9,7 @@ export default function Home() {
         title="Dashboard"
         description="Monitor your BullMQ job statistics"
       />
-      <StatsCards />
+      <EnhancedDashboard />
     </PageContainer>
   );
 }

--- a/apps/app/src/components/time-period-selector.tsx
+++ b/apps/app/src/components/time-period-selector.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { CalendarDays } from "lucide-react";
+import { useState } from "react";
+import { Button } from "~/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover";
+
+export type TimePeriod = "1" | "3" | "7" | "30";
+
+interface TimePeriodSelectorProps {
+  value: TimePeriod;
+  onChange: (period: TimePeriod) => void;
+}
+
+const timePeriodOptions: { value: TimePeriod; label: string }[] = [
+  { value: "1", label: "1 day" },
+  { value: "3", label: "3 days" },
+  { value: "7", label: "7 days" },
+  { value: "30", label: "30 days" },
+];
+
+export function TimePeriodSelector({
+  value,
+  onChange,
+}: TimePeriodSelectorProps) {
+  const [open, setOpen] = useState(false);
+
+  const selectedOption = timePeriodOptions.find(
+    (option) => option.value === value,
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-2">
+          <CalendarDays className="h-4 w-4" />
+          {selectedOption?.label || "1 day"}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-48 p-2" align="start">
+        <div className="space-y-1">
+          {timePeriodOptions.map((option) => (
+            <Button
+              key={option.value}
+              variant={value === option.value ? "default" : "ghost"}
+              size="sm"
+              className="w-full justify-start"
+              onClick={() => {
+                onChange(option.value);
+                setOpen(false);
+              }}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/app/src/components/ui/collapsible.tsx
+++ b/apps/app/src/components/ui/collapsible.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import * as React from "react"
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
 
 const Collapsible = CollapsiblePrimitive.Root

--- a/packages/clickhouse/src/crud/job-stats.ts
+++ b/packages/clickhouse/src/crud/job-stats.ts
@@ -2,6 +2,37 @@ import { addDays, addHours, startOfDay, startOfHour } from "date-fns";
 import { clickhouseClient } from "../lib/client";
 import type { JobStats, QueueStatsWithChart } from "./schemas";
 
+export interface EnhancedJobStats {
+  runningTasks: number;
+  waitingInQueue: number;
+  successes: number;
+  failures: number;
+}
+
+export interface QueuePerformanceData {
+  queue: string;
+  totalRuns: number;
+  successes: number;
+  failures: number;
+  errorRate: number;
+  avgDuration: number;
+}
+
+export interface QueueDurationData {
+  queue: string;
+  totalDuration: number;
+}
+
+export interface QueueCountData {
+  queue: string;
+  runCount: number;
+}
+
+export interface RunGraphData {
+  timestamp: string;
+  runCount: number;
+}
+
 export const getJobStats = async ({
   dateFrom,
   dateTo,
@@ -213,3 +244,315 @@ export const getQueueStatsWithChart = async ({
     throw new Error("Failed to fetch queue statistics with chart data");
   }
 };
+
+export const getEnhancedJobStats = async ({
+  dateFrom,
+  dateTo,
+}: {
+  dateFrom: Date;
+  dateTo: Date;
+}): Promise<EnhancedJobStats> => {
+  const runningTasksQuery = `
+    SELECT count() as count
+    FROM job_runs_ch 
+    WHERE status = 'active'
+  `;
+
+  const waitingInQueueQuery = `
+    SELECT count() as count
+    FROM job_runs_ch 
+    WHERE status = 'waiting'
+  `;
+
+  const successesQuery = `
+    SELECT count() as count
+    FROM job_runs_ch 
+    WHERE status = 'completed' 
+    AND created_at BETWEEN {date_from:DateTime64(3, 'UTC')} AND {date_to:DateTime64(3, 'UTC')}
+  `;
+
+  const failuresQuery = `
+    SELECT count() as count
+    FROM job_runs_ch 
+    WHERE status = 'failed' 
+    AND created_at BETWEEN {date_from:DateTime64(3, 'UTC')} AND {date_to:DateTime64(3, 'UTC')}
+  `;
+
+  try {
+    const [runningResult, waitingResult, successResult, failureResult] = await Promise.all([
+      clickhouseClient.query({
+        query: runningTasksQuery,
+        format: "JSONEachRow",
+      }),
+      clickhouseClient.query({
+        query: waitingInQueueQuery,
+        format: "JSONEachRow",
+      }),
+      clickhouseClient.query({
+        query: successesQuery,
+        query_params: { date_from: dateFrom, date_to: dateTo },
+        format: "JSONEachRow",
+      }),
+      clickhouseClient.query({
+        query: failuresQuery,
+        query_params: { date_from: dateFrom, date_to: dateTo },
+        format: "JSONEachRow",
+      }),
+    ]);
+
+    const [runningData, waitingData, successData, failureData] = await Promise.all([
+      runningResult.json(),
+      waitingResult.json(),
+      successResult.json(),
+      failureResult.json(),
+    ]);
+
+    return {
+      runningTasks: Number((runningData[0] as { count: string })?.count || "0"),
+      waitingInQueue: Number((waitingData[0] as { count: string })?.count || "0"),
+      successes: Number((successData[0] as { count: string })?.count || "0"),
+      failures: Number((failureData[0] as { count: string })?.count || "0"),
+    };
+  } catch (error) {
+    console.error("Error fetching enhanced job stats:", error);
+    throw new Error("Failed to fetch enhanced job statistics");
+  }
+};
+
+export const getQueuePerformanceData = async ({
+  dateFrom,
+  dateTo,
+}: {
+  dateFrom: Date;
+  dateTo: Date;
+}): Promise<QueuePerformanceData[]> => {
+  const query = `
+    SELECT 
+      queue,
+      count() as total_runs,
+      countIf(status = 'completed') as successes,
+      countIf(status = 'failed') as failures,
+      avgIf(
+        finished_at - started_at,
+        status = 'completed' AND started_at IS NOT NULL AND finished_at IS NOT NULL
+      ) as avg_duration_seconds
+    FROM job_runs_ch 
+    WHERE created_at BETWEEN {date_from:DateTime64(3, 'UTC')} AND {date_to:DateTime64(3, 'UTC')}
+    GROUP BY queue
+    ORDER BY total_runs DESC
+  `;
+
+  try {
+    const result = await clickhouseClient.query({
+      query,
+      query_params: { date_from: dateFrom, date_to: dateTo },
+      format: "JSONEachRow",
+    });
+
+    const data = (await result.json()) as {
+      queue: string;
+      total_runs: string;
+      successes: string;
+      failures: string;
+      avg_duration_seconds: string;
+    }[];
+
+    return data.map((item) => {
+      const totalRuns = Number(item.total_runs);
+      const successes = Number(item.successes);
+      const failures = Number(item.failures);
+      return {
+        queue: item.queue,
+        totalRuns,
+        successes,
+        failures,
+        errorRate: totalRuns > 0 ? (failures / totalRuns) * 100 : 0,
+        avgDuration: Number(item.avg_duration_seconds) || 0,
+      };
+    });
+  } catch (error) {
+    console.error("Error fetching queue performance data:", error);
+    throw new Error("Failed to fetch queue performance data");
+  }
+};
+
+export const getTopQueuesByDuration = async ({
+  dateFrom,
+  dateTo,
+  limit = 10,
+}: {
+  dateFrom: Date;
+  dateTo: Date;
+  limit?: number;
+}): Promise<QueueDurationData[]> => {
+  const query = `
+    SELECT 
+      queue,
+      sumIf(
+        finished_at - started_at,
+        status = 'completed' AND started_at IS NOT NULL AND finished_at IS NOT NULL
+      ) as total_duration_seconds
+    FROM job_runs_ch 
+    WHERE created_at BETWEEN {date_from:DateTime64(3, 'UTC')} AND {date_to:DateTime64(3, 'UTC')}
+    GROUP BY queue
+    HAVING total_duration_seconds > 0
+    ORDER BY total_duration_seconds DESC
+    LIMIT {limit:UInt32}
+  `;
+
+  try {
+    const result = await clickhouseClient.query({
+      query,
+      query_params: { date_from: dateFrom, date_to: dateTo, limit },
+      format: "JSONEachRow",
+    });
+
+    const data = (await result.json()) as {
+      queue: string;
+      total_duration_seconds: string;
+    }[];
+
+    return data.map((item) => ({
+      queue: item.queue,
+      totalDuration: Number(item.total_duration_seconds),
+    }));
+  } catch (error) {
+    console.error("Error fetching top queues by duration:", error);
+    throw new Error("Failed to fetch top queues by duration");
+  }
+};
+
+export const getTopQueuesByRunCount = async ({
+  dateFrom,
+  dateTo,
+  limit = 10,
+}: {
+  dateFrom: Date;
+  dateTo: Date;
+  limit?: number;
+}): Promise<QueueCountData[]> => {
+  const query = `
+    SELECT 
+      queue,
+      count() as run_count
+    FROM job_runs_ch 
+    WHERE created_at BETWEEN {date_from:DateTime64(3, 'UTC')} AND {date_to:DateTime64(3, 'UTC')}
+    GROUP BY queue
+    ORDER BY run_count DESC
+    LIMIT {limit:UInt32}
+  `;
+
+  try {
+    const result = await clickhouseClient.query({
+      query,
+      query_params: { date_from: dateFrom, date_to: dateTo, limit },
+      format: "JSONEachRow",
+    });
+
+    const data = (await result.json()) as {
+      queue: string;
+      run_count: string;
+    }[];
+
+    return data.map((item) => ({
+      queue: item.queue,
+      runCount: Number(item.run_count),
+    }));
+  } catch (error) {
+    console.error("Error fetching top queues by run count:", error);
+    throw new Error("Failed to fetch top queues by run count");
+  }
+};
+
+export const getRunGraphData = async ({
+  dateFrom,
+  dateTo,
+  timePeriod,
+}: {
+  dateFrom: Date;
+  dateTo: Date;
+  timePeriod: number;
+}): Promise<RunGraphData[]> => {
+  let interval: string;
+  let stepKind: string;
+  
+  if (timePeriod <= 1) {
+    interval = "toStartOfHour(created_at)";
+    stepKind = "hour";
+  } else if (timePeriod <= 7) {
+    interval = "toStartOfHour(created_at)";
+    stepKind = "hour";
+  } else {
+    interval = "toStartOfDay(created_at)";
+    stepKind = "day";
+  }
+
+  const query = `
+    SELECT 
+      ${interval} as timestamp,
+      count() as run_count
+    FROM job_runs_ch 
+    WHERE created_at BETWEEN {date_from:DateTime64(3, 'UTC')} AND {date_to:DateTime64(3, 'UTC')}
+    GROUP BY timestamp
+    ORDER BY timestamp
+  `;
+
+  try {
+    const result = await clickhouseClient.query({
+      query,
+      query_params: { date_from: dateFrom, date_to: dateTo },
+      format: "JSONEachRow",
+    });
+
+    const data = (await result.json()) as {
+      timestamp: string;
+      run_count: string;
+    }[];
+
+    const chartData = data.map((item) => ({
+      timestamp: item.timestamp,
+      runCount: Number(item.run_count),
+    }));
+
+    return fillRunGraphData(dateFrom, dateTo, stepKind, chartData);
+  } catch (error) {
+    console.error("Error fetching run graph data:", error);
+    throw new Error("Failed to fetch run graph data");
+  }
+};
+
+function fillRunGraphData(
+  dateFrom: Date,
+  dateTo: Date,
+  stepKind: string,
+  chartData: { timestamp: string; runCount: number }[],
+): RunGraphData[] {
+  const filled: RunGraphData[] = [];
+  const map = new Map(
+    chartData.map((d) => [
+      new Date(d.timestamp).toISOString().slice(0, 19).replace("T", " "),
+      d,
+    ]),
+  );
+
+  for (
+    let d = new Date(dateFrom);
+    d <= dateTo;
+    // biome-ignore lint/suspicious/noAssignInExpressions: easier
+    stepKind === "hour" ? (d = addHours(d, 1)) : (d = addDays(d, 1))
+  ) {
+    const ts =
+      stepKind === "hour"
+        ? startOfHour(d).toISOString().slice(0, 19).replace("T", " ")
+        : startOfDay(d).toISOString().slice(0, 19).replace("T", " ");
+
+    if (map.has(ts)) {
+      filled.push(
+        map.get(ts) as { timestamp: string; runCount: number },
+      );
+    } else {
+      filled.push({ timestamp: ts, runCount: 0 });
+    }
+  }
+  return filled;
+}

--- a/packages/clickhouse/src/crud/schemas.ts
+++ b/packages/clickhouse/src/crud/schemas.ts
@@ -57,3 +57,34 @@ export interface QueueStatsWithChart {
   completedJobs: number;
   chartData: QueueChartData[];
 }
+
+export interface EnhancedJobStats {
+  runningTasks: number;
+  waitingInQueue: number;
+  successes: number;
+  failures: number;
+}
+
+export interface QueuePerformanceData {
+  queue: string;
+  totalRuns: number;
+  successes: number;
+  failures: number;
+  errorRate: number;
+  avgDuration: number;
+}
+
+export interface QueueDurationData {
+  queue: string;
+  totalDuration: number;
+}
+
+export interface QueueCountData {
+  queue: string;
+  runCount: number;
+}
+
+export interface RunGraphData {
+  timestamp: string;
+  runCount: number;
+}


### PR DESCRIPTION
Add a new comprehensive dashboard to the home page with time range selection for detailed BullMQ job statistics.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae0e2268-2cba-4267-b223-e87a022b257e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae0e2268-2cba-4267-b223-e87a022b257e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

