### PR TITLE
Add npm publish command to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,26 @@ docker-compose -f docker/compose.local.yaml up -d
 # Run the development servers
 npm run dev
 ```
+
+## Publishing
+
+### Publishing the Client Package
+
+To publish the `@better-bull-board/client` package to npm for others to use:
+
+1. Navigate to the client package directory:
+   ```bash
+   cd packages/client
+   ```
+
+2. Build the package:
+   ```bash
+   npm run build
+   ```
+
+3. Publish to npm:
+   ```bash
+   npm publish
+   ```
+
+**Note**: Make sure you're logged in to npm (`npm login`) and have the appropriate permissions to publish under the `@better-bull-board` scope. You may also want to update the version in `package.json` before publishing.


### PR DESCRIPTION
Add instructions to the README for publishing the `@better-bull-board/client` package to npm so it can be used by others.

---
<a href="https://cursor.com/background-agent?bcId=bc-40ac2513-f20f-469f-a5b0-d59ca483b90e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-40ac2513-f20f-469f-a5b0-d59ca483b90e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

