### PR TITLE
Document project usage and self-hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Better Bull Board
 
+> **⚠️ Early Stage Project**: This project is in early development stage and is designed for internal use. Documentation and features may be incomplete or subject to significant changes. Use at your own discretion.
+
 ## What we store
 - **Queues**: via polling
 - **Schedulers**: via polling
@@ -78,3 +80,82 @@ To publish the `@better-bull-board/client` package to npm for others to use:
    ```
 
 **Note**: Make sure you're logged in to npm (`npm login`) and have the appropriate permissions to publish under the `@better-bull-board` scope. You may also want to update the version in `package.json` before publishing.
+
+## DevOps Self-Hosting Guide
+
+This section is for DevOps teams looking to self-host Better Bull Board in their infrastructure.
+
+### Architecture Requirements
+
+Better Bull Board requires the following infrastructure components:
+
+- **PostgreSQL**: Primary database with extensions (pgvector, PostGIS, pg_uuidv7)
+- **ClickHouse**: Analytics database for job metrics and logs  
+- **Redis**: External Redis/Dragonfly instance for queue management
+- **Kubernetes Cluster**: For orchestration (EKS recommended)
+- **Ingress Controller**: nginx-ingress recommended
+- **Container Registry**: For hosting Docker images
+
+### Self-Hosting Options
+
+#### Option 1: Kubernetes Deployment (Recommended)
+
+For production deployments, use our Kubernetes manifests:
+
+1. **Build and Push Images**: Follow the [Docker Build Guide](DOCKER_BUILD_GUIDE.md) to build and push images to your container registry
+2. **Configure Environment**: Set up your environment variables and secrets
+3. **Deploy**: Use the provided K8s manifests in the `k8s/` directory
+
+```bash
+# Quick deployment
+set -a && source k8s/.env && set +a
+envsubst < k8s/02-secrets-configmap.yaml.template > k8s/02-secrets-configmap.yaml
+kubectl apply -f k8s/
+```
+
+See the [Kubernetes Deployment Guide](KUBERNETES_DEPLOYMENT.md) for detailed instructions.
+
+#### Option 2: Docker Compose (Development)
+
+For local development or testing:
+
+```bash
+# Start services
+docker-compose -f docker/compose.local.yaml up -d
+
+# Run development servers  
+npm run dev
+```
+
+### Key Configuration
+
+#### Environment Variables
+
+Essential environment variables to configure:
+
+- **Database**: PostgreSQL connection settings
+- **ClickHouse**: Analytics database configuration  
+- **Redis**: Queue management connection
+- **Security**: Authentication and session management
+- **Domains**: Frontend and API endpoints
+
+#### External Dependencies
+
+- **Redis/Dragonfly**: Must be externally managed (not included in our manifests)
+- **SSL/TLS**: Configure cert-manager or load balancer SSL termination
+- **Monitoring**: Set up logging and metrics collection for the services
+
+#### Scaling Considerations
+
+- **App Service**: Horizontally scalable (multiple replicas supported)
+- **Ingest Service**: NOT scalable (single instance only)
+- **Database**: Use managed services (AWS RDS, etc.) for production
+- **ClickHouse**: Consider clustering for high-volume deployments
+
+### Security Notes
+
+> ⚠️ **Important**: This project is in early development and intended for internal use. Ensure proper network isolation, authentication, and access controls before exposing to production traffic.
+
+### Support
+
+As this is an early-stage internal tool, community support is limited. Review the existing documentation and configuration files for guidance, or adapt the deployment to your specific infrastructure requirements.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We are clearing the data from the following entities:
 This project is designed to be easily deployable on Kubernetes. All necessary configuration files are provided in the `k8s/` directory.
 
 **Quick Start:**
-1. Build and push Docker images to your registry (see [Docker Build Guide](DOCKER_BUILD_GUIDE.md))
+1. Build and push Docker images to your registry or use the existing images (see [Docker Build Guide](DOCKER_BUILD_GUIDE.md))
 2. Update configuration files with your registry URLs and domain
 3. Deploy to Kubernetes using the provided manifests
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,0 +1,161 @@
+# @better-bull-board/client
+
+Developer documentation for integrating Better Bull Board with your BullMQ workers.
+
+## Installation
+
+```bash
+npm install @better-bull-board/client
+```
+
+## Usage
+
+To use Better Bull Board with your BullMQ workers, you need to:
+
+1. **Import the BBB client** 
+2. **Use a separate processor** (sandboxed processor required for job cancellation)
+
+### Basic Setup
+
+#### 1. Create a Processor File
+
+Create a separate processor file (e.g., `processor.ts` or `processor.js`):
+
+```typescript
+import { patch } from "@better-bull-board/client";
+import type { SandboxedJob } from "bullmq";
+import { redis } from "./lib/redis"; // Your Redis connection
+
+export default patch(async (job: SandboxedJob) => {
+  console.log(`Processing job ${job.id}`);
+  
+  // Your job processing logic here
+  await processYourJob(job.data);
+  
+  console.log(`Job ${job.id} completed`);
+  
+  return { status: "done" };
+}, redis);
+```
+
+#### 2. Create a Worker
+
+Use the Better Bull Board Worker class in your main worker file:
+
+```typescript
+import path from "node:path";
+import { Worker } from "@better-bull-board/client";
+import { redis } from "./lib/redis"; // Your Redis connection
+
+const processorFile = path.join(__dirname, "processor.cjs"); // Note: .cjs extension for built files
+
+new Worker("your-queue-name", processorFile, {
+  connection: redis,
+  ioredis: redis,
+  useWorkerThreads: true,
+  concurrency: 10,
+  getJobTags(job) {
+    // Optional: Return tags for better organization
+    return ["your-queue", "production"];
+  },
+});
+```
+
+### Key Requirements
+
+- **Separate Processor**: You must use a sandboxed processor (separate file) for job cancellation to work properly
+- **Redis Connection**: Provide both `connection` and `ioredis` options pointing to the same Redis instance  
+- **Worker Threads**: Set `useWorkerThreads: true` for proper isolation
+- **File Extension**: Use `.cjs` extension for the processor file path when referencing built files
+
+### Complete Example
+
+Here's a complete working example based on our demo:
+
+**processor.ts**
+```typescript
+import { patch } from "@better-bull-board/client";
+import type { SandboxedJob } from "bullmq";
+import { redis } from "../lib/redis";
+
+export default patch(async (job: SandboxedJob) => {
+  console.log(`Processing job ${job.id}`);
+
+  // Simulate work
+  await new Promise((resolve) => setTimeout(resolve, 10_000));
+
+  console.log(`Job ${job.id} processed`);
+
+  return { status: "done" };
+}, redis);
+```
+
+**worker.ts**
+```typescript
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "@better-bull-board/client";
+import { redis } from "./lib/redis";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const processorFile = path.join(__dirname, "processor.cjs");
+
+new Worker("demo-queue", processorFile, {
+  connection: redis,
+  ioredis: redis,
+  useWorkerThreads: true,
+  concurrency: 10,
+  getJobTags() {
+    return ["demo-queue", "test"];
+  },
+});
+```
+
+### Advanced Features
+
+#### Job Cancellation
+
+The `patch` function provides built-in job cancellation support. Jobs can be cancelled through the Better Bull Board UI.
+
+#### Console Logging
+
+All console output from your processors is automatically captured and sent to Better Bull Board for monitoring.
+
+#### Job Tags
+
+Use the `getJobTags` function to organize and filter your jobs in the Better Bull Board interface:
+
+```typescript
+getJobTags(job) {
+  return [
+    job.queueName,
+    job.data.priority || "normal",
+    process.env.NODE_ENV || "development"
+  ];
+}
+```
+
+## API Reference
+
+### `patch(processor, redis)`
+
+Wraps your job processor with Better Bull Board functionality.
+
+- `processor`: Your async job processing function
+- `redis`: Redis connection instance
+
+### `Worker`
+
+Extended BullMQ Worker with Better Bull Board integration.
+
+**Required Options:**
+- `ioredis`: Redis connection instance
+- `useWorkerThreads`: Must be `true`
+- `getJobTags`: Optional function to return job tags
+
+## Troubleshooting
+
+- **Job cancellation not working**: Ensure you're using a sandboxed processor (separate file)
+- **Jobs not appearing**: Check that your Redis connection is properly configured
+- **Build issues**: Make sure to reference `.cjs` files for built processors


### PR DESCRIPTION
Add developer documentation for `@better-bull-board/client` and a DevOps self-hosting guide, along with an early-stage project disclaimer.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ede54e0-0887-4d93-b533-6b566ad4057d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ede54e0-0887-4d93-b533-6b566ad4057d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

