### PR TITLE
refactor: replace useRouter with Link component in RunsFilters

### DIFF
--- a/apps/app/src/app/runs/_components/runs-filters.tsx
+++ b/apps/app/src/app/runs/_components/runs-filters.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { ChevronLeft, ChevronRight, Filter, Plus, Search, X } from "lucide-react";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useMemo, useState } from "react";
 import { getTagsApiRoute } from "~/app/api/tags/schemas";
 import { QueueSelector } from "~/components/queue-selector";
@@ -11,8 +11,8 @@ import { Button } from "~/components/ui/button";
 import { Combobox, type ComboboxOption } from "~/components/ui/combobox";
 import { Input } from "~/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
-import { apiFetch } from "~/lib/utils/client";
 import useDebounce from "~/hooks/use-debounce";
+import { apiFetch } from "~/lib/utils/client";
 import type { TRunFilters } from "./types";
 
 export function RunsFilters({
@@ -29,7 +29,6 @@ export function RunsFilters({
   };
   startEndContent?: React.ReactNode;
 }) {
-  const router = useRouter();
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [queueOpen, setQueueOpen] = useState(false);
   const [statusOpen, setStatusOpen] = useState(false);
@@ -285,9 +284,11 @@ export function RunsFilters({
         {startEndContent}
       </div>
       <div className="flex items-center gap-2">
-        <Button onClick={() => router.push("/runs/create")} size="sm" className="gap-1">
-          <Plus className="h-4 w-4" />
-          Create Run
+        <Button asChild size="sm" className="gap-1">
+          <Link href="/runs/create">
+            <Plus className="h-4 w-4" />
+            Create Run
+          </Link>
         </Button>
         <Button variant="outline" size="sm" onClick={handlePrevPage} disabled={!runs?.prevCursor && !filters.cursor}>
           <ChevronLeft className="h-4 w-4" />


### PR DESCRIPTION
This should turn the button into a normal link so it can allow middle click open in a new tab functionality.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `useRouter` with `Link` component for "Create Run" navigation in `RunsFilters`
> Switches the "Create Run" button in [runs-filters.tsx](https://github.com/dimension-studios-inc/better-bull-board/pull/27/files#diff-196724bce29faa77501bf1a45d4b1c08c90e3d79830a52f74cc21cfb4f528e65) from imperative navigation (`router.push`) to a declarative Next.js `Link` rendered via `Button` with `asChild`. Removes the `useRouter` import and its associated `onClick` handler.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a91229.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->