### PR TITLE
feat: improve tag search performance in API and UI

### DIFF
--- a/apps/app/src/app/api/tags/route.ts
+++ b/apps/app/src/app/api/tags/route.ts
@@ -4,32 +4,30 @@ import { sql } from "drizzle-orm";
 import { createAuthenticatedApiRoute } from "~/lib/utils/server";
 import { getTagsApiRoute } from "./schemas";
 
+const MIN_TAG_SEARCH_LENGTH = 3;
+
 export const POST = createAuthenticatedApiRoute({
   apiRoute: getTagsApiRoute,
   async handler(input) {
-    const { search } = input;
+    const search = input.search?.trim();
 
-    // Use a subquery to unnest tags first, then filter on the unnested values
-    // We can't use unnest() in WHERE, so we unnest in a subquery and filter in the outer query
+    if (!search || search.length < MIN_TAG_SEARCH_LENGTH) {
+      return { tags: [] };
+    }
+
     const tags = await db.execute(
-      search
-        ? sql`
-          SELECT DISTINCT unnested_tag AS tag
-          FROM (
-            SELECT unnest(jr.tags) AS unnested_tag
+      sql`
+          WITH matching_runs AS (
+            SELECT jr.tags
             FROM ${jobRunsTable} jr
-          ) AS unnested_tags
-          WHERE unnested_tag ILIKE ${`%${search}%`}
-          ORDER BY unnested_tag
-          LIMIT 100
-        `
-        : sql`
-          SELECT DISTINCT unnested_tag AS tag
-          FROM (
-            SELECT unnest(jr.tags) AS unnested_tag
-            FROM ${jobRunsTable} jr
-          ) AS unnested_tags
-          ORDER BY unnested_tag
+            WHERE cardinality(jr.tags) > 0
+              AND public.job_runs_tags_search_text(jr.tags) ILIKE ${`%${search}%`}
+          )
+          SELECT DISTINCT unnested_tags.tag
+          FROM matching_runs
+          CROSS JOIN LATERAL unnest(matching_runs.tags) AS unnested_tags(tag)
+          WHERE unnested_tags.tag ILIKE ${`%${search}%`}
+          ORDER BY unnested_tags.tag
           LIMIT 100
         `,
     );

--- a/apps/app/src/app/runs/_components/runs-filters.tsx
+++ b/apps/app/src/app/runs/_components/runs-filters.tsx
@@ -15,6 +15,8 @@ import useDebounce from "~/hooks/use-debounce";
 import { apiFetch } from "~/lib/utils/client";
 import type { TRunFilters } from "./types";
 
+const MIN_TAG_SEARCH_LENGTH = 3;
+
 export function RunsFilters({
   filters,
   setFilters,
@@ -46,7 +48,7 @@ export function RunsFilters({
       apiRoute: getTagsApiRoute,
       body: { search: debouncedTagsSearch },
     }),
-    enabled: tagsOpen && debouncedTagsSearch.length >= 2,
+    enabled: tagsOpen && debouncedTagsSearch.length >= MIN_TAG_SEARCH_LENGTH,
   });
 
   const statusOptions: ComboboxOption[] = [
@@ -242,7 +244,11 @@ export function RunsFilters({
                       }}
                       options={tagsOptions.filter((option) => !filters.tags.includes(option.value))}
                       placeholder="Type to search tags..."
-                      noOptionsMessage={debouncedTagsSearch.length < 2 ? "Type at least 2 characters" : "No tags found"}
+                      noOptionsMessage={
+                        debouncedTagsSearch.length < MIN_TAG_SEARCH_LENGTH
+                          ? "Type at least 3 characters"
+                          : "No tags found"
+                      }
                       searchPlaceholder="Search tags..."
                       search={tagsSearch}
                       setSearch={setTagsSearch}
@@ -253,7 +259,7 @@ export function RunsFilters({
                       isFetching={isTagsFetching}
                       popoverContentClassName="w-80"
                     />
-                    <div className="text-xs text-muted-foreground">Start typing to search (2+ chars).</div>
+                    <div className="text-xs text-muted-foreground">Start typing to search (3+ chars).</div>
                   </div>
                 </div>
               </div>

--- a/packages/db/drizzle/0012_nosy_proudstar.sql
+++ b/packages/db/drizzle/0012_nosy_proudstar.sql
@@ -1,0 +1,11 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION public.job_runs_tags_search_text(tags text[])
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+RETURNS NULL ON NULL INPUT
+AS $$ SELECT array_to_string(tags, ' ') $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ix_job_runs_tags_text_trgm" ON "job_runs" USING gin ((public.job_runs_tags_search_text("tags")) gin_trgm_ops) WHERE cardinality("job_runs"."tags") > 0;

--- a/packages/db/drizzle/meta/0012_snapshot.json
+++ b/packages/db/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,633 @@
+{
+  "id": "1bb0da49-edb6-49da-82ed-10cbd9639aba",
+  "prevId": "48b279e3-cc6f-430a-8a67-fe3b72b9d825",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.job_logs": {
+      "name": "job_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v7()"
+        },
+        "job_run_id": {
+          "name": "job_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "log_seq": {
+          "name": "log_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ix_job_logs_job_run_ts": {
+          "name": "ix_job_logs_job_run_ts",
+          "columns": [
+            {
+              "expression": "job_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_job_logs_ts_brin": {
+          "name": "ix_job_logs_ts_brin",
+          "columns": [
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "brin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_logs_job_run_id_job_runs_id_fk": {
+          "name": "job_logs_job_run_id_job_runs_id_fk",
+          "tableFrom": "job_logs",
+          "tableTo": "job_runs",
+          "columnsFrom": ["job_run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_runs": {
+      "name": "job_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v7()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "queue": {
+          "name": "queue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "job_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_attempts": {
+          "name": "max_attempts",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delay_ms": {
+          "name": "delay_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backoff": {
+          "name": "backoff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repeat_job_key": {
+          "name": "repeat_job_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_job_id": {
+          "name": "parent_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "worker_id": {
+          "name": "worker_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "ARRAY[]::text[]"
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "enqueued_at": {
+          "name": "enqueued_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "EXTRACT(EPOCH FROM (finished_at - started_at)) * 1000",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "ux_job_runs_jobid_enqueuedat": {
+          "name": "ux_job_runs_jobid_enqueuedat",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enqueued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_job_runs_queue_created_at": {
+          "name": "ix_job_runs_queue_created_at",
+          "columns": [
+            {
+              "expression": "queue",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_job_runs_created_at": {
+          "name": "ix_job_runs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_job_runs_job": {
+          "name": "ix_job_runs_job",
+          "columns": [
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_job_runs_status_created_at": {
+          "name": "ix_job_runs_status_created_at",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_job_runs_status": {
+          "name": "ix_job_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_job_runs_repeat_key": {
+          "name": "ix_job_runs_repeat_key",
+          "columns": [
+            {
+              "expression": "repeat_job_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ix_job_runs_tags_gin": {
+          "name": "ix_job_runs_tags_gin",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "ix_job_runs_tags_text_trgm": {
+          "name": "ix_job_runs_tags_text_trgm",
+          "columns": [
+            {
+              "expression": "(public.job_runs_tags_search_text(\"tags\")) gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "cardinality(\"job_runs\".\"tags\") > 0",
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "ix_job_runs_data_gin": {
+          "name": "ix_job_runs_data_gin",
+          "columns": [
+            {
+              "expression": "data",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_schedulers": {
+      "name": "job_schedulers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v7()"
+        },
+        "queue_id": {
+          "name": "queue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "limit": {
+          "name": "limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tz": {
+          "name": "tz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "every": {
+          "name": "every",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template": {
+          "name": "template",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "ix_job_schedulers_key": {
+          "name": "ix_job_schedulers_key",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "job_schedulers_queue_id_queues_id_fk": {
+          "name": "job_schedulers_queue_id_queues_id_fk",
+          "tableFrom": "job_schedulers",
+          "tableTo": "queues",
+          "columnsFrom": ["queue_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.queues": {
+      "name": "queues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v7()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_job_options": {
+          "name": "default_job_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "is_paused": {
+          "name": "is_paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "ix_queues_name": {
+          "name": "ix_queues_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.job_status": {
+      "name": "job_status",
+      "schema": "public",
+      "values": ["active", "completed", "failed", "waiting"]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": ["log", "debug", "info", "warn", "error"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1761732873888,
       "tag": "0011_late_joystick",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1776863821700,
+      "tag": "0012_nosy_proudstar",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schemas/job/schema.ts
+++ b/packages/db/src/schemas/job/schema.ts
@@ -46,6 +46,9 @@ export const jobRunsTable = pgTable(
     index("ix_job_runs_status").on(t.status),
     index("ix_job_runs_repeat_key").on(t.repeatJobKey),
     index("ix_job_runs_tags_gin").using("gin", t.tags),
+    index("ix_job_runs_tags_text_trgm")
+      .using("gin", sql`(public.job_runs_tags_search_text(${t.tags})) gin_trgm_ops`)
+      .where(sql`cardinality(${t.tags}) > 0`),
     index("ix_job_runs_data_gin").using("gin", t.data),
   ],
 );


### PR DESCRIPTION
Make tag search less noisy and a lot cheaper to run. Searches now wait for 3 characters before kicking in and the API uses a faster database path for matching tags.

The database change also switches the tag search index to a trigram-backed GIN index, which is a better fit for partial string matching than the previous setup.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve tag search performance with GIN trigram index and 3-character minimum
> - Adds a `pg_trgm` GIN index on `job_runs` via a new `public.job_runs_tags_search_text(tags)` function that joins tag arrays into a space-delimited string, scoped to rows with non-empty tags.
> - Rewrites the tag search query in [`route.ts`](https://github.com/dimension-studios-inc/better-bull-board/pull/28/files#diff-53578a7eee60cfa99282b0f9d52b12149ab1b961b14b10407df017076e287cc5) to use a CTE that prefilters via `ILIKE` on the search text function before unnesting individual tags with `CROSS JOIN LATERAL`.
> - Enforces a 3-character minimum (`MIN_TAG_SEARCH_LENGTH`) in both the API and [`runs-filters.tsx`](https://github.com/dimension-studios-inc/better-bull-board/pull/28/files#diff-196724bce29faa77501bf1a45d4b1c08c90e3d79830a52f74cc21cfb4f528e65); the UI shows helper text prompting users to type at least 3 characters.
> - Behavioral Change: tag search requests with fewer than 3 characters now return an empty list instead of querying the database.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3144ded.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->