### PR TITLE
feat: improve job creation and queue selection functionality

### DIFF
--- a/apps/app/src/app/api/jobs/create/handler.ts
+++ b/apps/app/src/app/api/jobs/create/handler.ts
@@ -33,5 +33,7 @@ export const createJobHandler = async (input: {
     };
   } catch (error) {
     throw new Error(`Failed to create job: ${error instanceof Error ? error.message : "Unknown error"}`);
+  } finally {
+    await queue.close();
   }
 };

--- a/apps/app/src/app/api/jobs/create/schemas.ts
+++ b/apps/app/src/app/api/jobs/create/schemas.ts
@@ -2,8 +2,8 @@ import z from "zod";
 import { registerApiRoute } from "~/lib/utils/client";
 
 export const createJobInput = z.object({
-  queueName: z.string().min(1, "Queue name is required"),
-  jobName: z.string().min(1, "Job name is required"),
+  queueName: z.string().trim().min(1, "Queue name is required"),
+  jobName: z.string().trim().min(1, "Job name is required"),
   data: z.record(z.string(), z.unknown()).optional().default({}),
   options: z
     .object({

--- a/apps/app/src/app/runs/create/page.tsx
+++ b/apps/app/src/app/runs/create/page.tsx
@@ -119,6 +119,7 @@ export default function CreateRunPage() {
             placeholder="Select a queue..."
             className="w-full"
             popoverContentClassName="w-2xl"
+            allowCustomValue
           />
           {selectedQueue && selectedQueue !== "all" && isLastRunLoading && (
             <p className="text-sm text-muted-foreground">Loading last run data...</p>

--- a/apps/app/src/components/queue-selector.tsx
+++ b/apps/app/src/components/queue-selector.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { getQueuesNameApiRoute } from "~/app/api/queues/name/schemas";
 import { Combobox, type ComboboxOption } from "~/components/ui/combobox";
+import useDebounce from "~/hooks/use-debounce";
 import { useInfiniteScroll } from "~/hooks/use-infinite-scroll";
 import { apiFetch } from "~/lib/utils/client";
 
@@ -40,25 +41,26 @@ export function QueueSelector({
   allOptionLabel = "All Queues",
   allowCustomValue = false,
 }: QueueSelectorProps) {
+  const debouncedSearch = useDebounce(search, 250);
   const {
     data: queues,
     isLoading,
-    isFetching: isQueuesFetching,
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
   } = useInfiniteQuery({
-    queryKey: ["queues/name", search],
+    queryKey: ["queues/name", debouncedSearch],
     queryFn: ({ pageParam }: { pageParam: string | null }) =>
       apiFetch({
         apiRoute: getQueuesNameApiRoute,
         body: {
-          search,
+          search: debouncedSearch,
           cursor: pageParam,
         },
       })(),
     getNextPageParam: (lastPage) => lastPage.nextCursor,
     initialPageParam: null,
+    placeholderData: keepPreviousData,
   });
 
   const { loaderRef } = useInfiniteScroll({
@@ -71,10 +73,16 @@ export function QueueSelector({
 
   const queueOptions: ComboboxOption[] = useMemo(() => {
     const options = includeAllOption ? [{ value: "all", label: allOptionLabel }] : [];
+    const normalizedSearch = search.trim().toLowerCase();
+
     if (queues?.pages) {
       queues.pages.forEach((page) => {
         if (page?.queues) {
           page.queues.forEach((queue) => {
+            if (normalizedSearch && !queue.name.toLowerCase().includes(normalizedSearch)) {
+              return;
+            }
+
             options.push({ value: queue.name, label: queue.name });
           });
         }
@@ -117,7 +125,7 @@ export function QueueSelector({
       setOpen={setOpen}
       renderValue={renderValue || defaultRenderValue}
       className={className}
-      isFetching={isQueuesFetching}
+      isFetching={isLoading}
       infiniteLoadingProps={{
         hasNextPage,
         fetchNextPage,

--- a/apps/app/src/components/queue-selector.tsx
+++ b/apps/app/src/components/queue-selector.tsx
@@ -7,6 +7,8 @@ import { Combobox, type ComboboxOption } from "~/components/ui/combobox";
 import { useInfiniteScroll } from "~/hooks/use-infinite-scroll";
 import { apiFetch } from "~/lib/utils/client";
 
+const getCustomQueueOptionLabel = (queueName: string) => `Use custom queue "${queueName}"`;
+
 interface QueueSelectorProps {
   value: string;
   onValueChange: (value: string) => void;
@@ -20,6 +22,7 @@ interface QueueSelectorProps {
   renderValue?: (value: string) => string;
   includeAllOption?: boolean;
   allOptionLabel?: string;
+  allowCustomValue?: boolean;
 }
 
 export function QueueSelector({
@@ -35,6 +38,7 @@ export function QueueSelector({
   renderValue,
   includeAllOption = false,
   allOptionLabel = "All Queues",
+  allowCustomValue = false,
 }: QueueSelectorProps) {
   const {
     data: queues,
@@ -76,12 +80,27 @@ export function QueueSelector({
         }
       });
     }
+    const customQueueName = search.trim();
+    const hasCustomQueueName = options.some((option) => option.value === customQueueName);
+
+    if (allowCustomValue && customQueueName && !hasCustomQueueName) {
+      options.push({
+        value: customQueueName,
+        label: getCustomQueueOptionLabel(customQueueName),
+      });
+    }
+
     return options;
-  }, [queues, includeAllOption, allOptionLabel]);
+  }, [queues, includeAllOption, allOptionLabel, allowCustomValue, search]);
 
   const defaultRenderValue = (value: string) => {
     const option = queueOptions?.find((opt) => opt.value === value);
-    return option ? option.label : isLoading ? "Loading..." : "";
+    if (!option) {
+      if (isLoading) return "Loading...";
+      return allowCustomValue ? value : "";
+    }
+
+    return option.label === getCustomQueueOptionLabel(option.value) ? option.value : option.label;
   };
 
   return (


### PR DESCRIPTION
Allow creating jobs with custom names instead of only allowing already created job names.

I also added debounce to the job name search since it was triggering too much on every key press.

https://github.com/user-attachments/assets/70a576d5-26dc-4507-9888-7af5a27ada9e



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve job creation queue handling and add custom queue name support
> - [`QueueSelector`](https://github.com/dimension-studios-inc/better-bull-board/pull/29/files#diff-6383cf5e92a3d46a46817d3f6d8c1b6f97227b2a8406bf49d200e645414b403a) gains an `allowCustomValue` prop that lets users type and select a queue name not present in the fetched list, with a labeled "Use custom queue" option.
> - Search requests in `QueueSelector` are now debounced by 250ms and previous results are preserved during refetches via `keepPreviousData`.
> - [`createJobInput` schema](https://github.com/dimension-studios-inc/better-bull-board/pull/29/files#diff-104843a94cb90b6cef522f42e1e5e46fce6283e486163c99e26f1550242eba55) now trims `queueName` and `jobName`, causing whitespace-only values to fail validation.
> - [`createJobHandler`](https://github.com/dimension-studios-inc/better-bull-board/pull/29/files#diff-21fc76c49d7aa388342627b619cc02a37b3035da4f657ad7f2f664e89c135a2b) always closes the BullMQ queue connection after a request, including on errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c58956a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->