### PR TITLE
fix: prevent removing all tags from filters

### DIFF
--- a/apps/app/src/app/runs/_components/runs-filters.tsx
+++ b/apps/app/src/app/runs/_components/runs-filters.tsx
@@ -105,6 +105,7 @@ export function RunsFilters({
         cursor: null,
         tags: newTags,
       });
+      return;
     }
 
     if (filterKey === "queue") {


### PR DESCRIPTION
Removing one tag from filters would remove all of them by mistake.

**Before**

https://github.com/user-attachments/assets/76880962-a375-4b44-8880-3191fcf0970a

**After**


https://github.com/user-attachments/assets/0bd625d6-f327-4de5-aac1-4daac56e1f41

