### PR TITLE
refactor: improve job reconciliation logic with type safety

### DIFF
--- a/apps/ingest/src/repeats/reconcile-jobs.ts
+++ b/apps/ingest/src/repeats/reconcile-jobs.ts
@@ -16,6 +16,11 @@ const NON_TERMINAL_STATUSES = ["waiting", "active", "delayed", "prioritized", "w
 let reconcileInterval: NodeJS.Timeout | null = null;
 let queueCursor = 0;
 
+const inspectUnexpectedJob = (job: unknown) => ({
+  type: typeof job,
+  value: job,
+});
+
 const isBullMqJob = (job: Job | undefined): job is Job => Boolean(job?.id && typeof job.getState === "function");
 
 const getQueueNames = async () => {
@@ -43,7 +48,11 @@ const reconcileRetainedBullMqJobs = async (queue: Queue, queueName: string) => {
 
     for (const job of jobs) {
       if (!isBullMqJob(job)) {
-        logger.warn("Skipping missing BullMQ job during reconciliation", { queueName, start });
+        logger.warn("Skipping unexpected BullMQ job during reconciliation", {
+          queueName,
+          start,
+          job: inspectUnexpectedJob(job),
+        });
         continue;
       }
 

--- a/apps/ingest/src/repeats/reconcile-jobs.ts
+++ b/apps/ingest/src/repeats/reconcile-jobs.ts
@@ -1,7 +1,7 @@
 import { jobRunsTable, queuesTable } from "@better-bull-board/db";
 import { db } from "@better-bull-board/db/server";
 import { logger } from "@rharkor/logger";
-import { type JobType, Queue } from "bullmq";
+import { type Job, type JobType, Queue } from "bullmq";
 import { and, eq, inArray } from "drizzle-orm";
 import { acquireLock, releaseLock } from "~/lib/distributed-lock";
 import { env } from "~/lib/env";
@@ -15,6 +15,8 @@ const NON_TERMINAL_STATUSES = ["waiting", "active", "delayed", "prioritized", "w
 
 let reconcileInterval: NodeJS.Timeout | null = null;
 let queueCursor = 0;
+
+const isBullMqJob = (job: Job | undefined): job is Job => Boolean(job?.id && typeof job.getState === "function");
 
 const getQueueNames = async () => {
   const queues = await db.select({ name: queuesTable.name }).from(queuesTable);
@@ -40,6 +42,11 @@ const reconcileRetainedBullMqJobs = async (queue: Queue, queueName: string) => {
     if (jobs.length === 0) break;
 
     for (const job of jobs) {
+      if (!isBullMqJob(job)) {
+        logger.warn("Skipping missing BullMQ job during reconciliation", { queueName, start });
+        continue;
+      }
+
       const state = bullStateToPersistedStatus(await job.getState());
       rows.push(
         formatJobRun({
@@ -72,7 +79,7 @@ const reconcileMissingNonTerminalRows = async (queue: Queue, queueName: string) 
 
   for (const row of staleRows) {
     const job = await queue.getJob(row.jobId);
-    if (job) {
+    if (isBullMqJob(job)) {
       const state = bullStateToPersistedStatus(await job.getState());
       await safeUpsertJobRuns([
         formatJobRun({


### PR DESCRIPTION
After the new reconciliation flow went live, we started seeing cases where `queue.getJobs(...)` returned an entry that was no longer a usable bullmq job by the time the reconciler tried to read its state. This can happen when jobs are removed or expired while reconciliation is paging through the queue.

One missing job should not stop the full queue from being reconciled. If bullmq has already removed a job, the later stale row reconciliation path can still mark unresolved pg rows as `unknown`. So Added a small guard to confirm a bullmq job exists before calling `getState()`

