### PR TITLE
Fix job log stream backlog and stuck pending log events

### DIFF
--- a/apps/ingest/src/index.ts
+++ b/apps/ingest/src/index.ts
@@ -52,6 +52,7 @@ const h = monitorEventLoopDelay({ resolution: 20 });
 h.enable();
 setInterval(() => {
   const p99 = h.percentile(99) / 1e6; // ms
+  h.reset();
   if (p99 > 100) logger.warn("Event loop p99", p99, "ms");
 }, 2000);
 

--- a/apps/ingest/src/lib/ingest-events.ts
+++ b/apps/ingest/src/lib/ingest-events.ts
@@ -1,0 +1,13 @@
+import { logger } from "@rharkor/logger";
+import { redis } from "~/lib/redis";
+
+export const publishIngestEvent = (channel: string, message: string, context?: Record<string, unknown>) => {
+  void redis.publish(channel, message).catch((error) => {
+    logger.warn("Failed to publish ingest refresh event", {
+      channel,
+      message,
+      ...context,
+      error,
+    });
+  });
+};

--- a/apps/ingest/src/sync/job-stream.ts
+++ b/apps/ingest/src/sync/job-stream.ts
@@ -5,6 +5,12 @@ import { redis } from "~/lib/redis";
 import { formatJobRun, parseJobSyncEvent } from "./job-format";
 import { safeUpsertJobRuns } from "./job-upsert";
 
+const streamRedis = redis.duplicate();
+
+streamRedis.on("error", (error) => {
+  logger.error("Job stream Redis connection error", { error });
+});
+
 type StreamMessage = {
   id: string;
   fields: string[];
@@ -97,7 +103,7 @@ const processMessages = async (messages: StreamMessage[]) => {
 
 const readPendingMessages = async () => {
   try {
-    const response = await redis.call(
+    const response = await streamRedis.call(
       "XAUTOCLAIM",
       env.JOB_SYNC_STREAM_KEY,
       env.JOB_SYNC_CONSUMER_GROUP,
@@ -115,7 +121,7 @@ const readPendingMessages = async () => {
 };
 
 const readNewMessages = async () => {
-  const response = await redis.call(
+  const response = await streamRedis.call(
     "XREADGROUP",
     "GROUP",
     env.JOB_SYNC_CONSUMER_GROUP,

--- a/apps/ingest/src/sync/job-upsert.ts
+++ b/apps/ingest/src/sync/job-upsert.ts
@@ -3,7 +3,7 @@ import { db } from "@better-bull-board/db/server";
 import { conflictUpdateSet } from "@better-bull-board/db/utils/conflict-update";
 import { logger } from "@rharkor/logger";
 import { getTableName, sql } from "drizzle-orm";
-import { redis } from "~/lib/redis";
+import { publishIngestEvent } from "~/lib/ingest-events";
 import type { JobRunInsert } from "./job-format";
 
 export const upsertJobRuns = async (runs: JobRunInsert[]) => {
@@ -69,8 +69,11 @@ export const upsertJobRuns = async (runs: JobRunInsert[]) => {
       status: jobRunsTable.status,
     });
 
-  await redis.publish("bbb:ingest:events:job-refresh", "1");
-  await Promise.all(inserted.map((jobRun) => redis.publish("bbb:ingest:events:single-job-refresh", jobRun.id)));
+  publishIngestEvent("bbb:ingest:events:job-refresh", "1");
+  for (const jobRun of inserted) {
+    publishIngestEvent("bbb:ingest:events:single-job-refresh", jobRun.id, { jobRunId: jobRun.id });
+  }
+
   return inserted;
 };
 

--- a/apps/ingest/src/sync/log-buffer.ts
+++ b/apps/ingest/src/sync/log-buffer.ts
@@ -5,8 +5,8 @@ import { and, DrizzleQueryError, eq, inArray, or, sql } from "drizzle-orm";
 import { DatabaseError } from "pg";
 import { acquireLock, releaseLock } from "~/lib/distributed-lock";
 import { env } from "~/lib/env";
+import { publishIngestEvent } from "~/lib/ingest-events";
 import { instanceId } from "~/lib/instance";
-import { redis } from "~/lib/redis";
 
 export type LogEventForPersistence = {
   id?: string;
@@ -82,35 +82,38 @@ const resolveJobRunIds = async (events: LogEventForPersistence[]) => {
 const insertResolvedLogs = async (events: ResolvedLogEvent[]) => {
   if (events.length === 0) return;
 
-  const byRunId = new Map<string, LogEventForPersistence[]>();
-  for (const event of events) {
-    const rows = byRunId.get(event.jobRunId) ?? [];
-    rows.push(event);
-    byRunId.set(event.jobRunId, rows);
+  const sorted = [...events].sort((a, b) => {
+    const runCompare = a.jobRunId.localeCompare(b.jobRunId);
+    if (runCompare !== 0) return runCompare;
+
+    const timestampCompare = a.logTimestamp.getTime() - b.logTimestamp.getTime();
+    if (timestampCompare !== 0) return timestampCompare;
+
+    return a.logSeq - b.logSeq;
+  });
+
+  for (let i = 0; i < sorted.length; i += 500) {
+    const chunk = sorted.slice(i, i + 500);
+    await withDeadlockRetry(async () => {
+      await db
+        .insert(jobLogsTable)
+        .values(
+          chunk.map((row) => ({
+            jobRunId: row.jobRunId,
+            level: row.level,
+            message: row.message,
+            ts: row.logTimestamp,
+            logSeq: row.logSeq,
+          })),
+        )
+        .onConflictDoNothing({
+          target: [jobLogsTable.jobRunId, jobLogsTable.ts, jobLogsTable.logSeq],
+        });
+    });
   }
 
-  for (const jobRunId of Array.from(byRunId.keys()).sort()) {
-    const rows = byRunId.get(jobRunId) ?? [];
-    for (let i = 0; i < rows.length; i += 100) {
-      const chunk = rows.slice(i, i + 100);
-      await withDeadlockRetry(async () => {
-        await db
-          .insert(jobLogsTable)
-          .values(
-            chunk.map((row) => ({
-              jobRunId,
-              level: row.level,
-              message: row.message,
-              ts: row.logTimestamp,
-              logSeq: row.logSeq,
-            })),
-          )
-          .onConflictDoNothing({
-            target: [jobLogsTable.jobRunId, jobLogsTable.ts, jobLogsTable.logSeq],
-          });
-      });
-    }
-    await redis.publish("bbb:ingest:events:job-log-refresh", jobRunId);
+  for (const jobRunId of new Set(sorted.map((event) => event.jobRunId))) {
+    publishIngestEvent("bbb:ingest:events:job-log-refresh", jobRunId, { jobRunId });
   }
 };
 

--- a/apps/ingest/src/sync/log-stream.ts
+++ b/apps/ingest/src/sync/log-stream.ts
@@ -5,6 +5,12 @@ import { instanceId } from "~/lib/instance";
 import { redis } from "~/lib/redis";
 import { persistLogEvents } from "~/sync/log-buffer";
 
+const streamRedis = redis.duplicate();
+
+streamRedis.on("error", (error) => {
+  logger.error("Job log stream Redis connection error", { error });
+});
+
 type StreamMessage = {
   id: string;
   fields: string[];
@@ -120,7 +126,7 @@ const processMessages = async (messages: StreamMessage[]) => {
 
 const readPendingMessages = async () => {
   try {
-    const response = await redis.call(
+    const response = await streamRedis.call(
       "XAUTOCLAIM",
       env.JOB_LOG_SYNC_STREAM_KEY,
       env.JOB_LOG_SYNC_CONSUMER_GROUP,
@@ -138,7 +144,7 @@ const readPendingMessages = async () => {
 };
 
 const readNewMessages = async () => {
-  const response = await redis.call(
+  const response = await streamRedis.call(
     "XREADGROUP",
     "GROUP",
     env.JOB_LOG_SYNC_CONSUMER_GROUP,


### PR DESCRIPTION
This PR should fix the log ingestion slowdown we started seeing after moving job logs to Redis Streams.

Job syncing itself was healthy, but log ingestion had fallen far behind. In production, the log stream still had the missing log events, but the consumer group was stuck hundreds of thousands of messages behind. For affected runs, the logs were not missing from Redis. They just had not made it into Postgres yet.

There were two problems working together:

1. The log consumer could be slowed down by Redis connection contention. We were using the shared Redis client for blocking stream reads, while also using that same client for ack/delete and refresh events. On top of that, refresh publishes were awaited after DB writes, so a slow or failed publish could delay stream cleanup.

2. Log inserts were too big. A 500-message log batch could turn into hundreds of separate `INSERT job_logs` statements because we grouped inserts by `jobRunId`. In production, one sampled batch had 500 log events across 248 job runs, which meant far too many DB round trips for one stream batch.

This PR changes that path so the ingester can drain the backlog much more efficiently:

- use dedicated Redis connections for blocking job/log stream reads
- keep ack/delete and other Redis operations on the normal Redis client
- make ingest refresh publishes best-effort so UI refresh events cannot block stream acking
- bulk insert resolved log events in chunks instead of inserting once per job run
- keep `ON CONFLICT DO NOTHING`, so replayed or already-inserted pending messages remain idempotent
- reset the event-loop delay histogram after each sample so p99 warnings reflect current delay instead of repeating an old spike