### PR TITLE
Make job runs pagination faster and easier to scan

### DIFF
--- a/apps/app/src/app/api/jobs/table/route.ts
+++ b/apps/app/src/app/api/jobs/table/route.ts
@@ -5,16 +5,131 @@ import { z } from "zod";
 import { createAuthenticatedApiRoute } from "~/lib/utils/server";
 import { getJobsTableApiRoute } from "./schemas";
 
+type CursorDirection = "next" | "prev";
+type SortBy = "createdAt" | "durationMs";
+type SortDirection = "asc" | "desc";
+
+const jobTableColumns = {
+  id: jobRunsTable.id,
+  jobId: jobRunsTable.jobId,
+  queue: jobRunsTable.queue,
+  name: jobRunsTable.name,
+  status: jobRunsTable.status,
+  attempt: jobRunsTable.attempt,
+  maxAttempts: jobRunsTable.maxAttempts,
+  createdAt: jobRunsTable.createdAt,
+  enqueuedAt: jobRunsTable.enqueuedAt,
+  startedAt: jobRunsTable.startedAt,
+  finishedAt: jobRunsTable.finishedAt,
+  durationMs: jobRunsTable.durationMs,
+  errorMessage: jobRunsTable.errorMessage,
+  tags: jobRunsTable.tags,
+};
+
+type JobCursor = { createdAt: Date; jobId: string; id: string; durationMs?: number | null };
+
+const toCursor = (job: JobCursor) => ({
+  createdAt: job.createdAt,
+  jobId: job.jobId,
+  id: job.id,
+  durationMs: job.durationMs ?? null,
+});
+
+const getOrderDirection = (cursorDirection: CursorDirection, sortDirection: SortDirection) => {
+  if (cursorDirection === "next") return sortDirection;
+  return sortDirection === "desc" ? "asc" : "desc";
+};
+
+const getSortOrder = ({
+  cursorDirection,
+  durationSortExpression,
+  sortBy,
+  sortDirection,
+}: {
+  cursorDirection: CursorDirection;
+  durationSortExpression: ReturnType<typeof sql<number>>;
+  sortBy: SortBy;
+  sortDirection: SortDirection;
+}) => {
+  const orderDirection = getOrderDirection(cursorDirection, sortDirection);
+
+  if (sortBy === "durationMs") {
+    return orderDirection === "desc"
+      ? [desc(durationSortExpression), desc(jobRunsTable.createdAt), desc(jobRunsTable.jobId), desc(jobRunsTable.id)]
+      : [asc(durationSortExpression), asc(jobRunsTable.createdAt), asc(jobRunsTable.jobId), asc(jobRunsTable.id)];
+  }
+
+  return orderDirection === "desc"
+    ? [desc(jobRunsTable.createdAt), desc(jobRunsTable.jobId), desc(jobRunsTable.id)]
+    : [asc(jobRunsTable.createdAt), asc(jobRunsTable.jobId), asc(jobRunsTable.id)];
+};
+
+const getCreatedAtCursorComparison = ({
+  createdAt,
+  id,
+  jobId,
+  useLessThan,
+}: {
+  createdAt: Date;
+  id: string;
+  jobId: string;
+  useLessThan: boolean;
+}) =>
+  useLessThan
+    ? or(
+        lt(jobRunsTable.createdAt, createdAt),
+        and(eq(jobRunsTable.createdAt, createdAt), lt(jobRunsTable.jobId, jobId)),
+        and(eq(jobRunsTable.createdAt, createdAt), eq(jobRunsTable.jobId, jobId), lt(jobRunsTable.id, id)),
+      )
+    : or(
+        gt(jobRunsTable.createdAt, createdAt),
+        and(eq(jobRunsTable.createdAt, createdAt), gt(jobRunsTable.jobId, jobId)),
+        and(eq(jobRunsTable.createdAt, createdAt), eq(jobRunsTable.jobId, jobId), gt(jobRunsTable.id, id)),
+      );
+
+const getCursorComparison = ({
+  cursor,
+  cursorDirection,
+  durationSortExpression,
+  sortBy,
+  sortDirection,
+}: {
+  cursor: { createdAt: number; jobId: string; id: string; durationMs?: number | null };
+  cursorDirection: CursorDirection;
+  durationSortExpression: ReturnType<typeof sql<number>>;
+  sortBy: SortBy;
+  sortDirection: SortDirection;
+}) => {
+  const createdAt = new Date(cursor.createdAt);
+  const useLessThan = cursorDirection === "next" ? sortDirection === "desc" : sortDirection === "asc";
+  const createdAtComparison = getCreatedAtCursorComparison({
+    createdAt,
+    id: cursor.id,
+    jobId: cursor.jobId,
+    useLessThan,
+  });
+
+  if (sortBy !== "durationMs") {
+    return createdAtComparison;
+  }
+
+  const durationMs = cursor.durationMs ?? 0;
+  return or(
+    useLessThan ? lt(durationSortExpression, durationMs) : gt(durationSortExpression, durationMs),
+    and(eq(durationSortExpression, durationMs), createdAtComparison),
+  );
+};
+
 export const POST = createAuthenticatedApiRoute({
   apiRoute: getJobsTableApiRoute,
   async handler(input) {
-    const { cursor, search, queue, status, tags, createdFrom, createdTo } = input;
+    const { cursor, cursorDirection = "next", search, queue, status, tags, createdFrom, createdTo } = input;
     const limit = input.limit ?? 20;
     const sortBy = input.sortBy ?? "createdAt";
     const sortDirection = input.sortDirection ?? "desc";
     const durationSortExpression = sql<number>`COALESCE(${jobRunsTable.durationMs}, 0)`;
 
-    const getRows = async (direction: "next" | "prev") => {
+    const getRows = async (direction: CursorDirection) => {
       const conditions = [];
 
       if (search) {
@@ -54,74 +169,49 @@ export const POST = createAuthenticatedApiRoute({
       }
 
       if (cursor) {
-        // Cursor filtering
-        const { createdAt, jobId, id, durationMs } = cursor;
-        const createdAtDate = new Date(createdAt);
-
-        const isNext = direction === "next";
-        const isDescending = sortDirection === "desc";
-        const shouldUseLessThan = isNext === isDescending;
-
-        const createdAtComparison = shouldUseLessThan
-          ? or(
-              lt(jobRunsTable.createdAt, createdAtDate),
-              and(eq(jobRunsTable.createdAt, createdAtDate), lt(jobRunsTable.jobId, jobId)),
-              and(eq(jobRunsTable.createdAt, createdAtDate), eq(jobRunsTable.jobId, jobId), lt(jobRunsTable.id, id)),
-            )
-          : or(
-              gt(jobRunsTable.createdAt, createdAtDate),
-              and(eq(jobRunsTable.createdAt, createdAtDate), gt(jobRunsTable.jobId, jobId)),
-              and(eq(jobRunsTable.createdAt, createdAtDate), eq(jobRunsTable.jobId, jobId), gt(jobRunsTable.id, id)),
-            );
-
-        const comparison =
-          sortBy === "durationMs"
-            ? or(
-                shouldUseLessThan
-                  ? lt(durationSortExpression, durationMs ?? 0)
-                  : gt(durationSortExpression, durationMs ?? 0),
-                and(eq(durationSortExpression, durationMs ?? 0), createdAtComparison),
-              )
-            : createdAtComparison;
-
-        conditions.push(comparison);
+        conditions.push(
+          getCursorComparison({
+            cursor,
+            cursorDirection: direction,
+            durationSortExpression,
+            sortBy,
+            sortDirection,
+          }),
+        );
       }
 
-      // Determine sort order
-      const orderDirection = direction === "next" ? sortDirection : sortDirection === "desc" ? "asc" : "desc";
-      const order =
-        sortBy === "durationMs"
-          ? orderDirection === "desc"
-            ? [
-                desc(durationSortExpression),
-                desc(jobRunsTable.createdAt),
-                desc(jobRunsTable.jobId),
-                desc(jobRunsTable.id),
-              ]
-            : [asc(durationSortExpression), asc(jobRunsTable.createdAt), asc(jobRunsTable.jobId), asc(jobRunsTable.id)]
-          : orderDirection === "desc"
-            ? [desc(jobRunsTable.createdAt), desc(jobRunsTable.jobId), desc(jobRunsTable.id)]
-            : [asc(jobRunsTable.createdAt), asc(jobRunsTable.jobId), asc(jobRunsTable.id)];
+      const order = getSortOrder({
+        cursorDirection: direction,
+        durationSortExpression,
+        sortBy,
+        sortDirection,
+      });
 
-      // Fetch one extra record to detect next page
-      const result = await db
-        .select()
+      return db
+        .select(jobTableColumns)
         .from(jobRunsTable)
         .where(and(...conditions))
         .orderBy(...order)
         .limit(limit + 1);
-
-      return result;
     };
 
-    const jobs = await getRows("next");
-    const previousJobs = cursor ? await getRows("prev") : [];
+    const rows = await getRows(cursorDirection);
+    const hasExtra = rows.length > limit;
 
-    const nextCursor = jobs.length > limit ? (jobs.pop() ?? null) : null;
-    const prevCursor = previousJobs.length > limit ? (previousJobs.pop() ?? null) : null;
+    if (hasExtra) {
+      rows.pop();
+    }
 
-    const hasMore = nextCursor !== null;
+    const jobs = cursorDirection === "prev" ? rows.reverse() : rows;
+    const firstJob = jobs[0];
+    const lastJob = jobs.at(-1);
+    const hasNewerPage = cursorDirection === "next" ? Boolean(cursor) : hasExtra;
+    const hasOlderPage = cursorDirection === "prev" ? Boolean(cursor) : hasExtra;
 
-    return { jobs, nextCursor, prevCursor, hasMore };
+    return {
+      jobs,
+      nextCursor: hasOlderPage && lastJob ? toCursor(lastJob) : null,
+      prevCursor: hasNewerPage && firstJob ? toCursor(firstJob) : null,
+    };
   },
 });

--- a/apps/app/src/app/api/jobs/table/schemas.ts
+++ b/apps/app/src/app/api/jobs/table/schemas.ts
@@ -10,6 +10,7 @@ export const getJobsTableInput = z.object({
       durationMs: z.number().nullable().optional(),
     })
     .nullish(),
+  cursorDirection: z.enum(["next", "prev"]).optional(),
   search: z.string().optional(),
   status: z.string().optional(),
   queue: z.string().optional(),

--- a/apps/app/src/app/runs/_components/runs-filters.tsx
+++ b/apps/app/src/app/runs/_components/runs-filters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { ChevronLeft, ChevronRight, Filter, Plus, Search, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, Filter, Pause, Play, Plus, Search, X } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { getTagsApiRoute } from "~/app/api/tags/schemas";
@@ -20,6 +20,8 @@ export function RunsFilters({
   setFilters,
   runs,
   isFetching,
+  liveUpdatesPaused,
+  onLiveUpdatesPausedChange,
   startEndContent,
 }: {
   filters: TRunFilters;
@@ -29,6 +31,8 @@ export function RunsFilters({
     prevCursor: { createdAt: Date; jobId: string; id: string; durationMs?: number | null } | null;
   };
   isFetching?: boolean;
+  liveUpdatesPaused: boolean;
+  onLiveUpdatesPausedChange: (paused: boolean) => void;
   startEndContent?: React.ReactNode;
 }) {
   const [filtersOpen, setFiltersOpen] = useState(false);
@@ -337,6 +341,17 @@ export function RunsFilters({
         {startEndContent}
       </div>
       <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onLiveUpdatesPausedChange(!liveUpdatesPaused)}
+          className="size-9 p-0"
+          aria-pressed={liveUpdatesPaused}
+          aria-label={liveUpdatesPaused ? "Resume live updates" : "Pause live updates"}
+          title={liveUpdatesPaused ? "Resume live updates" : "Pause live updates"}
+        >
+          {liveUpdatesPaused ? <Play className="h-4 w-4" /> : <Pause className="h-4 w-4" />}
+        </Button>
         <Button asChild size="sm" className="gap-1">
           <Link href="/runs/create">
             <Plus className="h-4 w-4" />

--- a/apps/app/src/app/runs/_components/runs-filters.tsx
+++ b/apps/app/src/app/runs/_components/runs-filters.tsx
@@ -13,27 +13,22 @@ import { Input } from "~/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
 import useDebounce from "~/hooks/use-debounce";
 import { apiFetch } from "~/lib/utils/client";
-import type { TRunFilters } from "./types";
+import type { TRunFilters, TRunFilterUpdate } from "./types";
 
 export function RunsFilters({
   filters,
   setFilters,
   runs,
+  isFetching,
   startEndContent,
 }: {
   filters: TRunFilters;
-  setFilters: (
-    filters: Partial<
-      Pick<
-        TRunFilters,
-        "queue" | "status" | "search" | "tags" | "createdFrom" | "createdTo" | "sortBy" | "sortDirection" | "cursor"
-      >
-    >,
-  ) => void;
+  setFilters: (filters: TRunFilterUpdate) => void;
   runs?: {
     nextCursor: { createdAt: Date; jobId: string; id: string; durationMs?: number | null } | null;
     prevCursor: { createdAt: Date; jobId: string; id: string; durationMs?: number | null } | null;
   };
+  isFetching?: boolean;
   startEndContent?: React.ReactNode;
 }) {
   const [filtersOpen, setFiltersOpen] = useState(false);
@@ -173,6 +168,7 @@ export function RunsFilters({
           ...runs.nextCursor,
           createdAt: runs.nextCursor.createdAt.getTime(),
         },
+        cursorDirection: "next",
       });
     }
   };
@@ -184,9 +180,10 @@ export function RunsFilters({
           ...runs.prevCursor,
           createdAt: runs.prevCursor.createdAt.getTime(),
         },
+        cursorDirection: "prev",
       });
     } else {
-      setFilters({ cursor: null });
+      setFilters({ cursor: null, cursorDirection: "next" });
     }
   };
 
@@ -346,11 +343,16 @@ export function RunsFilters({
             Create Run
           </Link>
         </Button>
-        <Button variant="outline" size="sm" onClick={handlePrevPage} disabled={!runs?.prevCursor && !filters.cursor}>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handlePrevPage}
+          disabled={isFetching || (!runs?.prevCursor && !filters.cursor)}
+        >
           <ChevronLeft className="h-4 w-4" />
           Previous
         </Button>
-        <Button variant="outline" size="sm" onClick={handleNextPage} disabled={!runs?.nextCursor}>
+        <Button variant="outline" size="sm" onClick={handleNextPage} disabled={isFetching || !runs?.nextCursor}>
           Next
           <ChevronRight className="h-4 w-4" />
         </Button>

--- a/apps/app/src/app/runs/_components/runs-table.tsx
+++ b/apps/app/src/app/runs/_components/runs-table.tsx
@@ -5,8 +5,8 @@ import { formatDistanceStrict, formatDistanceToNowStrict } from "date-fns";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { parseAsString, useQueryStates } from "nuqs";
-import { useEffect, useMemo, useState } from "react";
+import { createParser, parseAsString, useQueryStates } from "nuqs";
+import { useMemo, useRef, useState } from "react";
 import { getJobsTableApiRoute } from "~/app/api/jobs/table/schemas";
 import { Badge } from "~/components/ui/badge";
 import { Checkbox } from "~/components/ui/checkbox";
@@ -16,7 +16,18 @@ import { apiFetch, cn } from "~/lib/utils/client";
 import { BulkActions } from "./bulk-actions";
 import { RunActions } from "./run-actions";
 import { RunsFilters } from "./runs-filters";
-import type { TRunFilters } from "./types";
+import type { TRunFilters, TRunFilterUpdate } from "./types";
+
+const parseAsCursor = createParser<NonNullable<TRunFilters["cursor"]>>({
+  parse: (value) => {
+    try {
+      return JSON.parse(Buffer.from(value, "base64").toString("utf-8"));
+    } catch {
+      return null;
+    }
+  },
+  serialize: (value) => Buffer.from(JSON.stringify(value)).toString("base64"),
+});
 
 export function RunsTable() {
   const router = useRouter();
@@ -29,64 +40,100 @@ export function RunsTable() {
     createdTo: parseAsString.withDefault(""),
     sortBy: parseAsString.withDefault("createdAt"),
     sortDirection: parseAsString.withDefault("desc"),
-    cursor: parseAsString.withDefault(""),
+    cursor: parseAsCursor,
+    cursorDirection: parseAsString.withDefault("next"),
   });
 
   const [selectedJobIds, setSelectedJobIds] = useState<Set<string>>(new Set());
+  const cursorHistoryRef = useRef<TRunFilters["cursor"][]>([]);
+  const cursorCreatedAt = urlFilters.cursor?.createdAt;
+  const cursorJobId = urlFilters.cursor?.jobId;
+  const cursorId = urlFilters.cursor?.id;
+  const cursorDurationMs = urlFilters.cursor?.durationMs;
 
   const filters: TRunFilters = useMemo(
     () => ({
-      ...urlFilters,
+      queue: urlFilters.queue,
+      status: urlFilters.status,
+      search: urlFilters.search,
+      createdFrom: urlFilters.createdFrom,
+      createdTo: urlFilters.createdTo,
       tags: urlFilters.tags ? urlFilters.tags.split(",").filter(Boolean) : [],
       sortBy: urlFilters.sortBy === "durationMs" ? "durationMs" : "createdAt",
       sortDirection: urlFilters.sortDirection === "asc" ? "asc" : "desc",
-      cursor: JSON.parse(Buffer.from(urlFilters.cursor, "base64").toString("utf-8") || "null") ?? null,
+      cursor:
+        cursorCreatedAt && cursorJobId && cursorId
+          ? {
+              createdAt: cursorCreatedAt,
+              jobId: cursorJobId,
+              id: cursorId,
+              durationMs: cursorDurationMs,
+            }
+          : null,
+      cursorDirection: urlFilters.cursorDirection === "prev" ? "prev" : "next",
       limit: 15,
     }),
-    [urlFilters],
+    [
+      urlFilters.queue,
+      urlFilters.status,
+      urlFilters.search,
+      urlFilters.tags,
+      urlFilters.createdFrom,
+      urlFilters.createdTo,
+      urlFilters.sortBy,
+      urlFilters.sortDirection,
+      cursorCreatedAt,
+      cursorJobId,
+      cursorId,
+      cursorDurationMs,
+      urlFilters.cursorDirection,
+    ],
   );
 
   const debouncedFilters = useDebounce(filters, 300);
+  const queryFilters = filters.cursor || filters.cursorDirection === "prev" ? filters : debouncedFilters;
 
-  const { data: runs } = useQuery({
-    queryKey: ["jobs/table", debouncedFilters],
+  const { data: runs, isFetching } = useQuery({
+    queryKey: ["jobs/table", queryFilters],
     queryFn: apiFetch({
       apiRoute: getJobsTableApiRoute,
-      body: debouncedFilters,
+      body: queryFilters,
     }),
   });
 
-  const handleFiltersChange = (
-    newFilters: Partial<
-      Pick<
-        TRunFilters,
-        "queue" | "status" | "search" | "tags" | "createdFrom" | "createdTo" | "sortBy" | "sortDirection" | "cursor"
-      >
-    >,
-  ) => {
-    const urlUpdate: Record<string, unknown> = Object.keys(newFilters).some((key) => key !== "cursor")
-      ? { cursor: "" }
-      : {};
+  const handleFiltersChange = (newFilters: TRunFilterUpdate) => {
+    const isPaginationOnly = Object.keys(newFilters).every((key) => key === "cursor" || key === "cursorDirection");
+    const urlUpdate: Record<string, unknown> = isPaginationOnly ? {} : { cursor: null, cursorDirection: "next" };
+
+    if (isPaginationOnly && newFilters.cursorDirection === "next") {
+      cursorHistoryRef.current.push(filters.cursor);
+    }
+
+    if (isPaginationOnly && newFilters.cursorDirection === "prev") {
+      const previousCursor = cursorHistoryRef.current.pop();
+
+      if (previousCursor !== undefined) {
+        newFilters = { cursor: previousCursor, cursorDirection: previousCursor ? "next" : "prev" };
+      }
+    }
+
+    if (!isPaginationOnly) {
+      cursorHistoryRef.current = [];
+    }
 
     for (const [key, value] of Object.entries(newFilters)) {
       if (key === "tags" && Array.isArray(value)) {
         urlUpdate[key] = value.length > 0 ? value.join(",") : "";
-      } else if (key === "cursor") {
-        urlUpdate[key] = Buffer.from(JSON.stringify(value || null)).toString("base64");
       } else {
         urlUpdate[key] = value;
       }
     }
 
+    setSelectedJobIds(new Set());
     setUrlFilters(urlUpdate);
   };
 
   const jobs = runs?.jobs || [];
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Clear selection when filters change
-  useEffect(() => {
-    setSelectedJobIds(new Set());
-  }, [debouncedFilters]);
 
   const selectedJobs = useMemo(() => {
     return jobs.filter((job) => selectedJobIds.has(job.jobId));
@@ -157,6 +204,7 @@ export function RunsTable() {
         filters={filters}
         setFilters={handleFiltersChange}
         runs={runs}
+        isFetching={isFetching}
         startEndContent={
           selectedJobs.length > 0 && (
             <BulkActions selectedJobs={selectedJobs} onClearSelection={() => setSelectedJobIds(new Set())} />

--- a/apps/app/src/app/runs/_components/runs-table.tsx
+++ b/apps/app/src/app/runs/_components/runs-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { formatDistanceStrict, formatDistanceToNowStrict } from "date-fns";
+import { format, formatDistanceStrict, formatDistanceToNowStrict } from "date-fns";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -27,6 +27,11 @@ const parseAsCursor = createParser<NonNullable<TRunFilters["cursor"]>>({
     }
   },
   serialize: (value) => Buffer.from(JSON.stringify(value)).toString("base64"),
+});
+
+const formatRunTimestamp = (value: Date) => ({
+  absolute: format(value, "MMM d, yyyy HH:mm:ss"),
+  relative: formatDistanceToNowStrict(value, { addSuffix: true }),
 });
 
 export function RunsTable() {
@@ -289,16 +294,24 @@ export function RunsTable() {
                       : "-"}
                   </TableCell>
                   <TableCell className="truncate">
-                    {formatDistanceToNowStrict(new Date(run.createdAt), {
-                      addSuffix: true,
-                    })}
+                    <time dateTime={run.createdAt.toISOString()} title={run.createdAt.toLocaleString()}>
+                      <span className="block truncate">{formatRunTimestamp(run.createdAt).relative}</span>
+                      <span className="block truncate text-xs text-muted-foreground">
+                        {formatRunTimestamp(run.createdAt).absolute}
+                      </span>
+                    </time>
                   </TableCell>
                   <TableCell className="truncate">
-                    {run.finishedAt
-                      ? formatDistanceToNowStrict(new Date(run.finishedAt), {
-                          addSuffix: true,
-                        })
-                      : "-"}
+                    {run.finishedAt ? (
+                      <time dateTime={run.finishedAt.toISOString()} title={run.finishedAt.toLocaleString()}>
+                        <span className="block truncate">{formatRunTimestamp(run.finishedAt).relative}</span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {formatRunTimestamp(run.finishedAt).absolute}
+                        </span>
+                      </time>
+                    ) : (
+                      "-"
+                    )}
                   </TableCell>
                   <TableCell
                     className={cn("max-w-48 truncate text-xs", {

--- a/apps/app/src/app/runs/_components/runs-table.tsx
+++ b/apps/app/src/app/runs/_components/runs-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { format, formatDistanceStrict, formatDistanceToNowStrict } from "date-fns";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
@@ -36,6 +36,7 @@ const formatRunTimestamp = (value: Date) => ({
 
 export function RunsTable() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [urlFilters, setUrlFilters] = useQueryStates({
     queue: parseAsString.withDefault("all"),
     status: parseAsString.withDefault("all"),
@@ -50,6 +51,7 @@ export function RunsTable() {
   });
 
   const [selectedJobIds, setSelectedJobIds] = useState<Set<string>>(new Set());
+  const [liveUpdatesPaused, setLiveUpdatesPaused] = useState(false);
   const cursorHistoryRef = useRef<TRunFilters["cursor"][]>([]);
   const cursorCreatedAt = urlFilters.cursor?.createdAt;
   const cursorJobId = urlFilters.cursor?.jobId;
@@ -97,13 +99,16 @@ export function RunsTable() {
 
   const debouncedFilters = useDebounce(filters, 300);
   const queryFilters = filters.cursor || filters.cursorDirection === "prev" ? filters : debouncedFilters;
+  const liveQueryKey = useMemo(() => ["jobs/table", queryFilters] as const, [queryFilters]);
 
   const { data: runs, isFetching } = useQuery({
-    queryKey: ["jobs/table", queryFilters],
+    queryKey: liveUpdatesPaused ? (["jobs/table-paused", queryFilters] as const) : liveQueryKey,
     queryFn: apiFetch({
       apiRoute: getJobsTableApiRoute,
       body: queryFilters,
     }),
+    initialData: liveUpdatesPaused ? () => queryClient.getQueryData(liveQueryKey) : undefined,
+    staleTime: liveUpdatesPaused ? Number.POSITIVE_INFINITY : undefined,
   });
 
   const handleFiltersChange = (newFilters: TRunFilterUpdate) => {
@@ -118,7 +123,7 @@ export function RunsTable() {
       const previousCursor = cursorHistoryRef.current.pop();
 
       if (previousCursor !== undefined) {
-        newFilters = { cursor: previousCursor, cursorDirection: previousCursor ? "next" : "prev" };
+        newFilters = { cursor: previousCursor, cursorDirection: "next" };
       }
     }
 
@@ -210,6 +215,8 @@ export function RunsTable() {
         setFilters={handleFiltersChange}
         runs={runs}
         isFetching={isFetching}
+        liveUpdatesPaused={liveUpdatesPaused}
+        onLiveUpdatesPausedChange={setLiveUpdatesPaused}
         startEndContent={
           selectedJobs.length > 0 && (
             <BulkActions selectedJobs={selectedJobs} onClearSelection={() => setSelectedJobIds(new Set())} />

--- a/apps/app/src/app/runs/_components/types.ts
+++ b/apps/app/src/app/runs/_components/types.ts
@@ -8,5 +8,22 @@ export type TRunFilters = {
   sortBy: "createdAt" | "durationMs";
   sortDirection: "asc" | "desc";
   cursor: { createdAt: number; jobId: string; id: string; durationMs?: number | null } | null;
+  cursorDirection: "next" | "prev";
   limit: number;
 };
+
+export type TRunFilterUpdate = Partial<
+  Pick<
+    TRunFilters,
+    | "queue"
+    | "status"
+    | "search"
+    | "tags"
+    | "createdFrom"
+    | "createdTo"
+    | "sortBy"
+    | "sortDirection"
+    | "cursor"
+    | "cursorDirection"
+  >
+>;

--- a/packages/db/drizzle/0016_job_runs_keyset_indexes.sql
+++ b/packages/db/drizzle/0016_job_runs_keyset_indexes.sql
@@ -1,0 +1,5 @@
+CREATE INDEX "ix_job_runs_created_at_job_id_id" ON "job_runs" USING btree ("created_at","job_id","id");--> statement-breakpoint
+CREATE INDEX "ix_job_runs_queue_created_at_job_id_id" ON "job_runs" USING btree ("queue","created_at","job_id","id");--> statement-breakpoint
+CREATE INDEX "ix_job_runs_status_created_at_job_id_id" ON "job_runs" USING btree ("status","created_at","job_id","id");--> statement-breakpoint
+CREATE INDEX "ix_job_runs_queue_status_created_at_job_id_id" ON "job_runs" USING btree ("queue","status","created_at","job_id","id");--> statement-breakpoint
+CREATE INDEX "ix_job_runs_duration_created_at_job_id_id" ON "job_runs" USING btree (COALESCE("duration_ms", 0),"created_at","job_id","id");

--- a/packages/db/src/schemas/job/schema.ts
+++ b/packages/db/src/schemas/job/schema.ts
@@ -39,6 +39,17 @@ export const jobRunsTable = pgTable(
   },
   (t) => [
     uniqueIndex("ux_job_runs_queue_jobid_enqueuedat").on(t.queue, t.jobId, t.enqueuedAt), // Job ids can overlap across queues.
+    index("ix_job_runs_created_at_job_id_id").on(t.createdAt, t.jobId, t.id),
+    index("ix_job_runs_queue_created_at_job_id_id").on(t.queue, t.createdAt, t.jobId, t.id),
+    index("ix_job_runs_status_created_at_job_id_id").on(t.status, t.createdAt, t.jobId, t.id),
+    index("ix_job_runs_queue_status_created_at_job_id_id").on(t.queue, t.status, t.createdAt, t.jobId, t.id),
+    index("ix_job_runs_duration_created_at_job_id_id").using(
+      "btree",
+      sql`COALESCE(${t.durationMs}, 0)`,
+      t.createdAt,
+      t.jobId,
+      t.id,
+    ),
     index("ix_job_runs_queue_created_at").on(t.queue, t.createdAt),
     index("ix_job_runs_created_at").on(t.createdAt),
     index("ix_job_runs_job").on(t.jobId),


### PR DESCRIPTION
Improve the Job Runs table so it behaves better when there are a lot of new runs coming in.

When new jobs were being added continuously, the table could shift while someone was trying to find a specific run. The relative-only timestamp also made it hard to match a row to an exact time.

This keeps the existing table mostly the same, but makes it easier to scan and less jumpy under live updates.

### What changed

- Reworked the job runs API to use explicit keyset pagination for next/previous navigation.
- Added `cursorDirection` so the client and API agree on whether we’re paging forward or backward.
- Added indexes for the common job run sort/filter paths.
- Added an icon-only pause/resume live updates button so users can freeze the table while they’re looking for a run.
- Updated Created and Finished cells to keep the relative time as the main text, with the exact timestamp shown underneath.


https://github.com/user-attachments/assets/68ab2ae3-68b8-4883-baa9-aba1fd6944ef

