### PR TITLE
feat: improve tag search with separate index table

### DIFF
--- a/apps/app/src/app/api/tags/route.ts
+++ b/apps/app/src/app/api/tags/route.ts
@@ -17,25 +17,17 @@ export const POST = createAuthenticatedApiRoute({
     const normalizedSearch = search.toLowerCase();
     const prefixSearch = `${normalizedSearch}%`;
     const containsSearch = `%${normalizedSearch}%`;
+    const searchPattern = normalizedSearch.length === 2 ? prefixSearch : containsSearch;
 
-    const tags =
-      normalizedSearch.length === 2
-        ? await db.execute(sql`
-            SELECT "tag"
-            FROM "job_tags"
-            WHERE "tag_lower" LIKE ${prefixSearch}
-            ORDER BY "tag"
-            LIMIT 100
-          `)
-        : await db.execute(sql`
-            SELECT "tag"
-            FROM "job_tags"
-            WHERE "tag_lower" LIKE ${containsSearch}
-            ORDER BY
-              CASE WHEN "tag_lower" LIKE ${prefixSearch} THEN 0 ELSE 1 END,
-              "tag"
-            LIMIT 100
-          `);
+    const tags = await db.execute(sql`
+      SELECT "tag"
+      FROM "job_tags"
+      WHERE "tag_lower" LIKE ${searchPattern}
+      ORDER BY
+        CASE WHEN "tag_lower" LIKE ${prefixSearch} THEN 0 ELSE 1 END,
+        "tag"
+      LIMIT 100
+    `);
 
     return {
       tags: (tags.rows as { tag: string }[]).map((row) => row.tag).filter(Boolean),

--- a/apps/app/src/app/api/tags/route.ts
+++ b/apps/app/src/app/api/tags/route.ts
@@ -1,10 +1,9 @@
-import { jobRunsTable } from "@better-bull-board/db";
 import { db } from "@better-bull-board/db/server";
 import { sql } from "drizzle-orm";
 import { createAuthenticatedApiRoute } from "~/lib/utils/server";
 import { getTagsApiRoute } from "./schemas";
 
-const MIN_TAG_SEARCH_LENGTH = 3;
+const MIN_TAG_SEARCH_LENGTH = 2;
 
 export const POST = createAuthenticatedApiRoute({
   apiRoute: getTagsApiRoute,
@@ -15,22 +14,28 @@ export const POST = createAuthenticatedApiRoute({
       return { tags: [] };
     }
 
-    const tags = await db.execute(
-      sql`
-          WITH matching_runs AS (
-            SELECT jr.tags
-            FROM ${jobRunsTable} jr
-            WHERE cardinality(jr.tags) > 0
-              AND public.job_runs_tags_search_text(jr.tags) ILIKE ${`%${search}%`}
-          )
-          SELECT DISTINCT unnested_tags.tag
-          FROM matching_runs
-          CROSS JOIN LATERAL unnest(matching_runs.tags) AS unnested_tags(tag)
-          WHERE unnested_tags.tag ILIKE ${`%${search}%`}
-          ORDER BY unnested_tags.tag
-          LIMIT 100
-        `,
-    );
+    const normalizedSearch = search.toLowerCase();
+    const prefixSearch = `${normalizedSearch}%`;
+    const containsSearch = `%${normalizedSearch}%`;
+
+    const tags =
+      normalizedSearch.length === 2
+        ? await db.execute(sql`
+            SELECT "tag"
+            FROM "job_tags"
+            WHERE "tag_lower" LIKE ${prefixSearch}
+            ORDER BY "tag"
+            LIMIT 100
+          `)
+        : await db.execute(sql`
+            SELECT "tag"
+            FROM "job_tags"
+            WHERE "tag_lower" LIKE ${containsSearch}
+            ORDER BY
+              CASE WHEN "tag_lower" LIKE ${prefixSearch} THEN 0 ELSE 1 END,
+              "tag"
+            LIMIT 100
+          `);
 
     return {
       tags: (tags.rows as { tag: string }[]).map((row) => row.tag).filter(Boolean),

--- a/apps/app/src/app/runs/_components/runs-filters.tsx
+++ b/apps/app/src/app/runs/_components/runs-filters.tsx
@@ -15,7 +15,7 @@ import useDebounce from "~/hooks/use-debounce";
 import { apiFetch } from "~/lib/utils/client";
 import type { TRunFilters, TRunFilterUpdate } from "./types";
 
-const MIN_TAG_SEARCH_LENGTH = 3;
+const MIN_TAG_SEARCH_LENGTH = 2;
 
 export function RunsFilters({
   filters,
@@ -284,7 +284,7 @@ export function RunsFilters({
                       placeholder="Type to search tags..."
                       noOptionsMessage={
                         debouncedTagsSearch.length < MIN_TAG_SEARCH_LENGTH
-                          ? "Type at least 3 characters"
+                          ? "Type at least 2 characters"
                           : "No tags found"
                       }
                       searchPlaceholder="Search tags..."
@@ -297,7 +297,7 @@ export function RunsFilters({
                       isFetching={isTagsFetching}
                       popoverContentClassName="w-80"
                     />
-                    <div className="text-xs text-muted-foreground">Start typing to search (3+ chars).</div>
+                    <div className="text-xs text-muted-foreground">Start typing to search (2+ chars).</div>
                   </div>
                 </div>
 

--- a/apps/ingest/src/index.ts
+++ b/apps/ingest/src/index.ts
@@ -6,6 +6,7 @@ import { startWebSocketServer } from "./lib/websocket-server";
 import { migrateDatabases } from "./migration";
 import { clearData } from "./repeats/clear-data";
 import { startDashboardRollups } from "./repeats/dashboard-rollups";
+import { startJobTagsRefresh } from "./repeats/job-tags";
 import { autoIngestQueues } from "./repeats/queues";
 import { autoReconcileJobs } from "./repeats/reconcile-jobs";
 import { startJobStreamIngestion } from "./sync/job-stream";
@@ -28,6 +29,7 @@ const main = async () => {
   autoResolveBufferedJobLogs();
   clearData();
   startDashboardRollups();
+  startJobTagsRefresh();
   autoIngestQueues();
   autoReconcileJobs();
 

--- a/apps/ingest/src/repeats/job-tags.ts
+++ b/apps/ingest/src/repeats/job-tags.ts
@@ -1,0 +1,67 @@
+import { db } from "@better-bull-board/db/server";
+import { logger } from "@rharkor/logger";
+import { sql } from "drizzle-orm";
+import cron from "node-cron";
+import { withLock } from "~/lib/distributed-lock";
+import { env } from "~/lib/env";
+import { instanceId } from "~/lib/instance";
+
+const JOB_TAGS_REFRESH_LOCK_KEY = "bbb:job-tags-refresh-lock";
+const JOB_TAGS_REFRESH_LOCK_TTL_MS = 1000 * 60 * 29;
+const JOB_TAGS_REFRESH_LOOKBACK_MS = 1000 * 60 * 60;
+
+export const refreshRecentJobTags = async () => {
+  const createdFrom = new Date(Date.now() - JOB_TAGS_REFRESH_LOOKBACK_MS);
+  const retentionMs = env.AUTO_DELETE_POSTGRES_DATA;
+  const deleteBefore = retentionMs ? new Date(Date.now() - retentionMs) : undefined;
+
+  await withLock({
+    key: JOB_TAGS_REFRESH_LOCK_KEY,
+    owner: instanceId,
+    ttlMs: JOB_TAGS_REFRESH_LOCK_TTL_MS,
+    run: async () => {
+      await db.transaction(async (tx) => {
+        await tx.execute(sql`
+          INSERT INTO "job_tags" ("tag", "tag_lower", "last_seen_at", "updated_at")
+          SELECT
+            unnested_tags.tag,
+            lower(unnested_tags.tag),
+            MAX("job_runs"."created_at")::timestamp,
+            now()
+          FROM "job_runs"
+          CROSS JOIN LATERAL unnest("job_runs"."tags") AS unnested_tags(tag)
+          WHERE "job_runs"."created_at" >= ${createdFrom}
+            AND cardinality("job_runs"."tags") > 0
+            AND unnested_tags.tag IS NOT NULL
+            AND unnested_tags.tag <> ''
+          GROUP BY unnested_tags.tag
+          ON CONFLICT ("tag") DO UPDATE SET
+            "tag_lower" = EXCLUDED."tag_lower",
+            "last_seen_at" = GREATEST("job_tags"."last_seen_at", EXCLUDED."last_seen_at"),
+            "updated_at" = now()
+        `);
+
+        if (deleteBefore) {
+          await tx.execute(sql`
+            DELETE FROM "job_tags"
+            WHERE "last_seen_at" < ${deleteBefore}
+          `);
+        }
+      });
+    },
+  });
+};
+
+export const startJobTagsRefresh = () => {
+  cron.schedule("*/30 * * * *", () => {
+    refreshRecentJobTags().catch((error) => {
+      logger.error("Failed to refresh job tags", { error });
+    });
+  });
+
+  refreshRecentJobTags().catch((error) => {
+    logger.error("Failed to refresh job tags on startup", { error });
+  });
+
+  logger.log("🏷️ Job tags refresh scheduled every 30 minutes");
+};

--- a/packages/db/drizzle/0018_cron_refreshed_job_tags.sql
+++ b/packages/db/drizzle/0018_cron_refreshed_job_tags.sql
@@ -1,0 +1,30 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "job_tags" (
+	"tag" text NOT NULL,
+	"tag_lower" text NOT NULL,
+	"last_seen_at" timestamp (3) NOT NULL,
+	"updated_at" timestamp (3) DEFAULT now() NOT NULL,
+	CONSTRAINT "pk_job_tags" PRIMARY KEY("tag")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ix_job_tags_tag_lower_pattern" ON "job_tags" USING btree ("tag_lower" text_pattern_ops);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ix_job_tags_tag_lower_trgm" ON "job_tags" USING gin ("tag_lower" gin_trgm_ops);
+--> statement-breakpoint
+INSERT INTO "job_tags" ("tag", "tag_lower", "last_seen_at", "updated_at")
+SELECT
+	unnested_tags.tag,
+	lower(unnested_tags.tag),
+	MAX("job_runs"."created_at")::timestamp,
+	now()
+FROM "job_runs"
+CROSS JOIN LATERAL unnest("job_runs"."tags") AS unnested_tags(tag)
+WHERE cardinality("job_runs"."tags") > 0
+	AND unnested_tags.tag IS NOT NULL
+	AND unnested_tags.tag <> ''
+GROUP BY unnested_tags.tag
+ON CONFLICT ("tag") DO UPDATE SET
+	"tag_lower" = EXCLUDED."tag_lower",
+	"last_seen_at" = GREATEST("job_tags"."last_seen_at", EXCLUDED."last_seen_at"),
+	"updated_at" = now();

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1777046900000,
       "tag": "0017_tag_search_trgm",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1777047000000,
+      "tag": "0018_cron_refreshed_job_tags",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schemas/index.ts
+++ b/packages/db/src/schemas/index.ts
@@ -2,3 +2,4 @@ export * from "./dashboard/schema";
 export * from "./job/enum";
 export * from "./job/schema";
 export * from "./queues/schema";
+export * from "./tags/schema";

--- a/packages/db/src/schemas/tags/schema.ts
+++ b/packages/db/src/schemas/tags/schema.ts
@@ -1,0 +1,21 @@
+import { sql } from "drizzle-orm";
+import { index, pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core";
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+
+export const jobTagsTable = pgTable(
+  "job_tags",
+  {
+    tag: text("tag").notNull(),
+    tagLower: text("tag_lower").notNull(),
+    lastSeenAt: timestamp("last_seen_at", { precision: 3, mode: "date" }).notNull(),
+    updatedAt: timestamp("updated_at", { precision: 3, mode: "date" }).notNull().default(sql`now()`),
+  },
+  (t) => [
+    primaryKey({ name: "pk_job_tags", columns: [t.tag] }),
+    index("ix_job_tags_tag_lower_pattern").using("btree", sql`${t.tagLower} text_pattern_ops`),
+    index("ix_job_tags_tag_lower_trgm").using("gin", sql`${t.tagLower} gin_trgm_ops`),
+  ],
+);
+
+export const jobTagsInsertSchema = createInsertSchema(jobTagsTable);
+export const jobTagsSelectSchema = createSelectSchema(jobTagsTable);


### PR DESCRIPTION
This PR replaces tag search over `job_runs` with a dedicated `job_tags` index table. The previous query was too slow because it searched a large, wide table, then unnested and deduplicated tag arrays before returning suggestions.

`job_tags` is refreshed by the ingest service every 30 minutes, similar to the dashboard rollup pattern. This keeps tag lookups fast without adding triggers or extra work to each job insert.

Local comparisons:
- Old `lumi` search: ~17s
- Old `final` search: ~38s
- Old `coffee` search: ~75s
- New `job_tags` lookups: under 1ms

The tag search minimum is now back to 2 characters as the current approach is fast enough to handle it.