### PR TITLE
fix: update job run timestamps to use consistent enqueuedAt value

### DIFF
--- a/apps/ingest/src/sync/job-format.ts
+++ b/apps/ingest/src/sync/job-format.ts
@@ -77,6 +77,8 @@ export const formatJobRun = ({
     throw new Error("Job ID is required");
   }
 
+  const enqueuedAt = new Date(job.timestamp);
+
   const formatted: JobRunInsert = {
     workerId,
     jobId: job.id,
@@ -88,7 +90,7 @@ export const formatJobRun = ({
     delayMs: job.opts.delay,
     backoff: job.opts.backoff,
     data: job.data,
-    enqueuedAt: new Date(job.timestamp),
+    enqueuedAt,
     startedAt: job.processedOn ? new Date(job.processedOn) : undefined,
     finishedAt: job.finishedOn ? new Date(job.finishedOn) : undefined,
     errorMessage: job.failedReason,
@@ -98,7 +100,7 @@ export const formatJobRun = ({
     repeatJobKey: job.repeatJobKey,
     result: job.returnvalue,
     tags,
-    createdAt: new Date(),
+    createdAt: enqueuedAt,
   };
 
   return jobRunsInsertSchema.parse(formatted);

--- a/apps/ingest/src/sync/job-upsert.ts
+++ b/apps/ingest/src/sync/job-upsert.ts
@@ -39,6 +39,7 @@ export const upsertJobRuns = async (runs: JobRunInsert[]) => {
           "errorStack",
           "result",
           "backoff",
+          "createdAt",
           "data",
           "priority",
           "delayMs",


### PR DESCRIPTION
When reconciliation found a retained BullMQ job that was missing from pg, we formatted it with `createdAt: new Date()`. That meant a job that actually ran days ago could be inserted into `job_runs` as if it had just been created. Since the runs table sorts by `created_at`, those older failed jobs appeared above more recent completed ones, even though their BullMQ timestamps and job IDs were older.

This changes ingest to use BullMQ’s own `job.timestamp` as the run `createdAt`, matching `enqueuedAt`. Reconciliation/upserts now preserve the job’s real creation time instead of the time we happened to discover it.

This is forward-looking only, existing historical rows are left unchanged.
