### PR TITLE
fix(ingest): Reduce Postgres-related ingester restarts

### DIFF
--- a/apps/ingest/src/index.ts
+++ b/apps/ingest/src/index.ts
@@ -1,4 +1,4 @@
-import { monitorEventLoopDelay } from "node:perf_hooks";
+import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import { logger } from "@rharkor/logger";
 import { env } from "./lib/env";
 import { startHealthServer } from "./lib/health-server";
@@ -53,11 +53,39 @@ const main = async () => {
 // }
 
 const h = monitorEventLoopDelay({ resolution: 20 });
+let eventLoopUsage = performance.eventLoopUtilization();
+let resourceUsage = process.resourceUsage();
 h.enable();
 setInterval(() => {
   const p99 = h.percentile(99) / 1e6; // ms
+  const nextEventLoopUsage = performance.eventLoopUtilization(eventLoopUsage);
+  const nextResourceUsage = process.resourceUsage();
+  const memoryUsage = process.memoryUsage();
+  const cpuUsage = {
+    systemMs: (nextResourceUsage.systemCPUTime - resourceUsage.systemCPUTime) / 1000,
+    userMs: (nextResourceUsage.userCPUTime - resourceUsage.userCPUTime) / 1000,
+  };
+
+  eventLoopUsage = performance.eventLoopUtilization();
+  resourceUsage = nextResourceUsage;
   h.reset();
-  if (p99 > 100) logger.warn("Event loop p99", p99, "ms");
+  if (p99 > 100) {
+    logger.warn("Event loop p99", {
+      cpuUsage,
+      eventLoopUtilization: {
+        activeMs: nextEventLoopUsage.active,
+        idleMs: nextEventLoopUsage.idle,
+        utilization: nextEventLoopUsage.utilization,
+      },
+      memoryUsage: {
+        externalMb: memoryUsage.external / 1024 / 1024,
+        heapTotalMb: memoryUsage.heapTotal / 1024 / 1024,
+        heapUsedMb: memoryUsage.heapUsed / 1024 / 1024,
+        rssMb: memoryUsage.rss / 1024 / 1024,
+      },
+      p99Ms: p99,
+    });
+  }
 }, 2000);
 
 main();

--- a/apps/ingest/src/sync/job-upsert.ts
+++ b/apps/ingest/src/sync/job-upsert.ts
@@ -2,9 +2,34 @@ import { jobRunsTable } from "@better-bull-board/db/schemas/job/schema";
 import { db } from "@better-bull-board/db/server";
 import { conflictUpdateSet } from "@better-bull-board/db/utils/conflict-update";
 import { logger } from "@rharkor/logger";
-import { getTableName, sql } from "drizzle-orm";
+import { DrizzleQueryError, getTableName, sql } from "drizzle-orm";
+import { DatabaseError } from "pg";
 import { publishIngestEvent } from "~/lib/ingest-events";
 import type { JobRunInsert } from "./job-format";
+
+async function withDeadlockRetry<T>(fn: () => Promise<T>, tries = 5): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < tries; i++) {
+    try {
+      return await fn();
+    } catch (error: unknown) {
+      if (error instanceof DrizzleQueryError && error.cause instanceof DatabaseError && error.cause.code === "40P01") {
+        lastErr = error;
+        if (i === tries - 1) break;
+        const backoff = 25 * (i + 1) + Math.floor(Math.random() * 50);
+        logger.warn("Retrying job_runs upsert after Postgres deadlock", {
+          attempt: i + 1,
+          maxAttempts: tries,
+          backoff,
+        });
+        await new Promise((resolve) => setTimeout(resolve, backoff));
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw lastErr;
+}
 
 export const upsertJobRuns = async (runs: JobRunInsert[]) => {
   if (runs.length === 0) return [];
@@ -16,59 +41,89 @@ export const upsertJobRuns = async (runs: JobRunInsert[]) => {
   }
 
   const values = Array.from(deduped.values()).sort((a, b) => {
-    const ae = a.enqueuedAt ? new Date(a.enqueuedAt).getTime() : 0;
-    const be = b.enqueuedAt ? new Date(b.enqueuedAt).getTime() : 0;
-    if (ae !== be) return ae - be;
     const queueCompare = a.queue.localeCompare(b.queue);
     if (queueCompare !== 0) return queueCompare;
-    return a.jobId.localeCompare(b.jobId);
+    const jobCompare = a.jobId.localeCompare(b.jobId);
+    if (jobCompare !== 0) return jobCompare;
+    const ae = a.enqueuedAt ? new Date(a.enqueuedAt).getTime() : 0;
+    const be = b.enqueuedAt ? new Date(b.enqueuedAt).getTime() : 0;
+    return ae - be;
   });
 
   const tableName = getTableName(jobRunsTable);
-  const inserted = await db
-    .insert(jobRunsTable)
-    .values(values)
-    .onConflictDoUpdate({
-      target: [jobRunsTable.queue, jobRunsTable.jobId, jobRunsTable.enqueuedAt],
-      set: {
-        ...conflictUpdateSet(jobRunsTable, [
-          "attempt",
-          "startedAt",
-          "finishedAt",
-          "errorMessage",
-          "errorStack",
-          "result",
-          "backoff",
-          "createdAt",
-          "data",
-          "priority",
-          "delayMs",
-          "repeatJobKey",
-          "parentJobId",
-          "workerId",
-          "enqueuedAt",
-          "jobId",
-          "maxAttempts",
-          "queue",
-          "name",
-        ]),
-        tags: sql.raw(`CASE
-          WHEN COALESCE(cardinality(excluded.${jobRunsTable.tags.name}), 0) > 0
-            THEN excluded.${jobRunsTable.tags.name}
-          ELSE ${tableName}.${jobRunsTable.tags.name}
-        END`),
-        status: sql.raw(`CASE
-          WHEN ${tableName}.${jobRunsTable.status.name} IN ('completed', 'failed')
-            AND excluded.${jobRunsTable.status.name} NOT IN ('completed', 'failed')
-            THEN ${tableName}.${jobRunsTable.status.name}
-          ELSE excluded.${jobRunsTable.status.name}
-        END`),
-      },
-    })
-    .returning({
-      id: jobRunsTable.id,
-      status: jobRunsTable.status,
-    });
+  const statusUpdateSql = `CASE
+    WHEN ${tableName}.${jobRunsTable.status.name} IN ('completed', 'failed')
+      AND excluded.${jobRunsTable.status.name} NOT IN ('completed', 'failed')
+      THEN ${tableName}.${jobRunsTable.status.name}
+    ELSE excluded.${jobRunsTable.status.name}
+  END`;
+  const tagsUpdateSql = `CASE
+    WHEN COALESCE(cardinality(excluded.${jobRunsTable.tags.name}), 0) > 0
+      THEN excluded.${jobRunsTable.tags.name}
+    ELSE ${tableName}.${jobRunsTable.tags.name}
+  END`;
+  const setWhere = sql.raw(`(
+    ${tableName}.${jobRunsTable.attempt.name} IS DISTINCT FROM excluded.${jobRunsTable.attempt.name}
+    OR ${tableName}.${jobRunsTable.startedAt.name} IS DISTINCT FROM excluded.${jobRunsTable.startedAt.name}
+    OR ${tableName}.${jobRunsTable.finishedAt.name} IS DISTINCT FROM excluded.${jobRunsTable.finishedAt.name}
+    OR ${tableName}.${jobRunsTable.errorMessage.name} IS DISTINCT FROM excluded.${jobRunsTable.errorMessage.name}
+    OR ${tableName}.${jobRunsTable.errorStack.name} IS DISTINCT FROM excluded.${jobRunsTable.errorStack.name}
+    OR ${tableName}.${jobRunsTable.result.name} IS DISTINCT FROM excluded.${jobRunsTable.result.name}
+    OR ${tableName}.${jobRunsTable.backoff.name} IS DISTINCT FROM excluded.${jobRunsTable.backoff.name}
+    OR ${tableName}.${jobRunsTable.createdAt.name} IS DISTINCT FROM excluded.${jobRunsTable.createdAt.name}
+    OR ${tableName}.${jobRunsTable.data.name} IS DISTINCT FROM excluded.${jobRunsTable.data.name}
+    OR ${tableName}.${jobRunsTable.priority.name} IS DISTINCT FROM excluded.${jobRunsTable.priority.name}
+    OR ${tableName}.${jobRunsTable.delayMs.name} IS DISTINCT FROM excluded.${jobRunsTable.delayMs.name}
+    OR ${tableName}.${jobRunsTable.repeatJobKey.name} IS DISTINCT FROM excluded.${jobRunsTable.repeatJobKey.name}
+    OR ${tableName}.${jobRunsTable.parentJobId.name} IS DISTINCT FROM excluded.${jobRunsTable.parentJobId.name}
+    OR ${tableName}.${jobRunsTable.workerId.name} IS DISTINCT FROM excluded.${jobRunsTable.workerId.name}
+    OR ${tableName}.${jobRunsTable.enqueuedAt.name} IS DISTINCT FROM excluded.${jobRunsTable.enqueuedAt.name}
+    OR ${tableName}.${jobRunsTable.jobId.name} IS DISTINCT FROM excluded.${jobRunsTable.jobId.name}
+    OR ${tableName}.${jobRunsTable.maxAttempts.name} IS DISTINCT FROM excluded.${jobRunsTable.maxAttempts.name}
+    OR ${tableName}.${jobRunsTable.queue.name} IS DISTINCT FROM excluded.${jobRunsTable.queue.name}
+    OR ${tableName}.${jobRunsTable.name.name} IS DISTINCT FROM excluded.${jobRunsTable.name.name}
+    OR ${tableName}.${jobRunsTable.tags.name} IS DISTINCT FROM (${tagsUpdateSql})
+    OR ${tableName}.${jobRunsTable.status.name} IS DISTINCT FROM (${statusUpdateSql})
+  )`);
+
+  const inserted = await withDeadlockRetry(() =>
+    db
+      .insert(jobRunsTable)
+      .values(values)
+      .onConflictDoUpdate({
+        target: [jobRunsTable.queue, jobRunsTable.jobId, jobRunsTable.enqueuedAt],
+        setWhere,
+        set: {
+          ...conflictUpdateSet(jobRunsTable, [
+            "attempt",
+            "startedAt",
+            "finishedAt",
+            "errorMessage",
+            "errorStack",
+            "result",
+            "backoff",
+            "createdAt",
+            "data",
+            "priority",
+            "delayMs",
+            "repeatJobKey",
+            "parentJobId",
+            "workerId",
+            "enqueuedAt",
+            "jobId",
+            "maxAttempts",
+            "queue",
+            "name",
+          ]),
+          tags: sql.raw(tagsUpdateSql),
+          status: sql.raw(statusUpdateSql),
+        },
+      })
+      .returning({
+        id: jobRunsTable.id,
+        status: jobRunsTable.status,
+      }),
+  );
 
   publishIngestEvent("bbb:ingest:events:job-refresh", "1");
   for (const jobRun of inserted) {

--- a/apps/ingest/src/sync/log-buffer.ts
+++ b/apps/ingest/src/sync/log-buffer.ts
@@ -166,7 +166,7 @@ export const persistLogEvents = async (events: LogEventForPersistence[]) => {
   await bufferUnresolvedLogs(unresolved);
 
   if (unresolved.length > 0) {
-    logger.info("Buffered unresolved job logs", {
+    logger.debug("Buffered unresolved job logs", {
       resolved: resolved.length,
       unresolved: unresolved.length,
       sample: unresolved.slice(0, 5).map((event) => ({

--- a/packages/db/src/lib/database.ts
+++ b/packages/db/src/lib/database.ts
@@ -16,6 +16,13 @@ const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
 });
 
+pool.on("error", (err) => {
+  logger.error("[DB Pool] Idle client error", {
+    message: err.message,
+    stack: err.stack,
+  });
+});
+
 const origQuery = pool.query.bind(pool);
 // biome-ignore lint/suspicious/noExplicitAny: _
 pool.query = async (...args: any[]) => {


### PR DESCRIPTION
Reduce ingester instability from transient Postgres failures and reduce the deadlock pressure in the `job_runs` write path. The process now handles idle Postgres pool errors instead of letting them terminate Node, and the bulk job upsert path retries deadlocks while taking locks in a more deterministic order.

**Postgres connection interruptions**

Idle `pg.Pool` client errors are now logged through the shared database client. This keeps administrator-initiated disconnects or short Postgres interruptions from surfacing as unhandled pool errors that can crash the ingester.

**Deadlock-resistant job upserts**

`job_runs` batches are sorted by the conflict key `(queue, jobId, enqueuedAt)` before insertion, so concurrent writers acquire row locks more consistently. The conflict update also skips rows with no material changes and retries `40P01` deadlocks with bounded backoff, while preserving terminal statuses and non-empty tags.