### PR TITLE
fix(ingest): Reduce restart pressure under load

### DIFF
--- a/apps/ingest/src/lib/concurrency.ts
+++ b/apps/ingest/src/lib/concurrency.ts
@@ -1,0 +1,12 @@
+export const mapWithConcurrency = async <T>(items: T[], concurrency: number, run: (item: T) => Promise<void>) => {
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const item = items[nextIndex];
+      nextIndex += 1;
+      if (item) await run(item);
+    }
+  });
+
+  await Promise.all(workers);
+};

--- a/apps/ingest/src/lib/health-server.ts
+++ b/apps/ingest/src/lib/health-server.ts
@@ -12,10 +12,28 @@ interface HealthCheckResult {
   error?: string;
 }
 
+const HEALTH_CHECK_TIMEOUT_MS = 2_000;
+
+const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number, service: string): Promise<T> => {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          reject(new Error(`${service} health check timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+};
+
 async function checkRedis(): Promise<HealthCheckResult> {
   const start = Date.now();
   try {
-    await redis.ping();
+    await withTimeout(redis.ping(), HEALTH_CHECK_TIMEOUT_MS, "redis");
     return {
       service: "redis",
       status: "healthy",
@@ -34,8 +52,7 @@ async function checkRedis(): Promise<HealthCheckResult> {
 async function checkDatabase(): Promise<HealthCheckResult> {
   const start = Date.now();
   try {
-    // Simple query to test PostgreSQL connection
-    await db.execute(sql`SELECT 1`);
+    await withTimeout(db.execute(sql`SELECT 1`), HEALTH_CHECK_TIMEOUT_MS, "postgresql");
     return {
       service: "postgresql",
       status: "healthy",
@@ -51,6 +68,23 @@ async function checkDatabase(): Promise<HealthCheckResult> {
   }
 }
 
+function handleLiveCheck(): {
+  response: string;
+  statusCode: number;
+} {
+  return {
+    response: JSON.stringify(
+      {
+        status: "healthy",
+        timestamp: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+    statusCode: 200,
+  };
+}
+
 async function handleHealthCheck(): Promise<{
   response: string;
   statusCode: number;
@@ -58,13 +92,11 @@ async function handleHealthCheck(): Promise<{
   const startTime = Date.now();
 
   try {
-    // Run all health checks in parallel
     const [redisResult, dbResult] = await Promise.all([checkRedis(), checkDatabase()]);
 
     const results = [redisResult, dbResult];
     const totalResponseTime = Date.now() - startTime;
 
-    // Check if all services are healthy
     const allHealthy = results.every((result) => result.status === "healthy");
 
     const response = {
@@ -73,8 +105,6 @@ async function handleHealthCheck(): Promise<{
       totalResponseTime,
       services: results,
     };
-
-    // Return 200 if all healthy, 503 if any service is unhealthy
     return {
       response: JSON.stringify(response, null, 2),
       statusCode: allHealthy ? 200 : 503,
@@ -110,7 +140,15 @@ function handleRequest(req: IncomingMessage, res: ServerResponse) {
     return;
   }
 
-  if (req.method === "GET" && url.pathname === "/health") {
+  if (req.method === "GET" && url.pathname === "/live") {
+    const { response, statusCode } = handleLiveCheck();
+    res.setHeader("Content-Type", "application/json");
+    res.writeHead(statusCode);
+    res.end(response);
+    return;
+  }
+
+  if (req.method === "GET" && (url.pathname === "/health" || url.pathname === "/ready")) {
     handleHealthCheck()
       .then(({ response, statusCode }) => {
         res.setHeader("Content-Type", "application/json");
@@ -143,7 +181,7 @@ function handleRequest(req: IncomingMessage, res: ServerResponse) {
     JSON.stringify(
       {
         error: "Not found",
-        message: "Only /health endpoint is available",
+        message: "Only /live, /ready, and /health endpoints are available",
       },
       null,
       2,

--- a/apps/ingest/src/repeats/dashboard-rollups.ts
+++ b/apps/ingest/src/repeats/dashboard-rollups.ts
@@ -19,6 +19,7 @@ export const refreshLastCompletedDashboardRollupHour = async () => {
     owner: instanceId,
     ttlMs: DASHBOARD_ROLLUP_LOCK_TTL_MS,
     run: async () => {
+      const start = Date.now();
       await db.transaction(async (tx) => {
         await tx.execute(sql`
           DELETE FROM "dashboard_queue_hourly_stats"
@@ -83,6 +84,9 @@ export const refreshLastCompletedDashboardRollupHour = async () => {
           DELETE FROM "dashboard_queue_hourly_stats"
           WHERE "bucket_start" < ${deleteBefore}
         `);
+      });
+      logger.debug("Dashboard rollups refresh completed", {
+        elapsedMs: Date.now() - start,
       });
     },
   });

--- a/apps/ingest/src/repeats/job-tags.ts
+++ b/apps/ingest/src/repeats/job-tags.ts
@@ -20,6 +20,7 @@ export const refreshRecentJobTags = async () => {
     owner: instanceId,
     ttlMs: JOB_TAGS_REFRESH_LOCK_TTL_MS,
     run: async () => {
+      const start = Date.now();
       await db.transaction(async (tx) => {
         await tx.execute(sql`
           INSERT INTO "job_tags" ("tag", "tag_lower", "last_seen_at", "updated_at")
@@ -47,6 +48,9 @@ export const refreshRecentJobTags = async () => {
             WHERE "last_seen_at" < ${deleteBefore}
           `);
         }
+      });
+      logger.debug("Job tags refresh completed", {
+        elapsedMs: Date.now() - start,
       });
     },
   });

--- a/apps/ingest/src/repeats/queues.ts
+++ b/apps/ingest/src/repeats/queues.ts
@@ -5,6 +5,7 @@ import { Queue } from "bullmq";
 import { and, eq, notInArray } from "drizzle-orm";
 import type Redis from "ioredis";
 import type { Cluster } from "ioredis";
+import { mapWithConcurrency } from "~/lib/concurrency";
 import { withLock } from "~/lib/distributed-lock";
 import { instanceId } from "~/lib/instance";
 import { redis } from "~/lib/redis";
@@ -12,22 +13,31 @@ import { getChangedKeys } from "~/utils";
 
 const maxCount = 150000;
 const maxTime = 40000;
+const QUEUE_INGEST_CONCURRENCY = 5;
 
 // Store interval ID for cleanup
 let queueIngestionInterval: NodeJS.Timeout | null = null;
+let queueIngestionRunning = false;
 
 // https://github.com/taskforcesh/taskforce-connector/blob/722b0e649452468d617ce239fb5dc534705a7d48/lib/queue-factory.ts#L27
 const scanForQueues = async (node: Redis | Cluster, startTime: number) => {
   let cursor = "0";
   const keys = [];
+  let scanCount = 0;
   do {
     const [nextCursor, scannedKeys] = await node.scan(cursor, "MATCH", "*:*:id", "COUNT", maxCount, "TYPE", "string");
     cursor = nextCursor;
+    scanCount += 1;
 
     keys.push(...scannedKeys);
   } while (Date.now() - startTime < maxTime && cursor !== "0");
 
-  return keys;
+  return {
+    complete: cursor === "0",
+    elapsedMs: Date.now() - startTime,
+    keys,
+    scanCount,
+  };
 };
 
 export const ingestQueues = async () => {
@@ -41,28 +51,50 @@ export const ingestQueues = async () => {
 };
 
 const ingestQueuesUnsafe = async () => {
+  const start = Date.now();
   try {
-    const allQueuesKeys = await scanForQueues(redis, Date.now());
+    const scan = await scanForQueues(redis, Date.now());
     // <namespace>:<queueName>:id
-    const allQueuesNames = allQueuesKeys.map((key) => key.split(":")[1]).filter((queueName) => queueName !== undefined);
+    const allQueuesNames = Array.from(
+      new Set(scan.keys.map((key) => key.split(":")[1]).filter((queueName) => queueName !== undefined)),
+    ).sort();
 
-    //* Delete all missing queues from database
-    await db.delete(queuesTable).where(notInArray(queuesTable.name, allQueuesNames));
+    logger.debug("Queue discovery completed", {
+      complete: scan.complete,
+      elapsedMs: scan.elapsedMs,
+      keyCount: scan.keys.length,
+      queueCount: allQueuesNames.length,
+      scanCount: scan.scanCount,
+    });
 
-    //* Upserting queues in database
-    await Promise.all(
-      allQueuesNames.map(async (queueName) => {
-        try {
-          // First upsert the queue
-          const queue = await upsertQueue(queueName);
-          // Then upsert the job schedulers
-          await upsertJobSchedulers(queueName, queue.id);
-        } catch (error) {
-          logger.error(`Error processing queue ${queueName}:`, error);
-          // Continue processing other queues even if one fails
-        }
-      }),
-    );
+    if (scan.complete) {
+      if (allQueuesNames.length > 0) {
+        await db.delete(queuesTable).where(notInArray(queuesTable.name, allQueuesNames));
+      } else {
+        await db.delete(queuesTable);
+      }
+    } else {
+      logger.warn("Skipping missing queue deletion after incomplete Redis queue scan", {
+        elapsedMs: scan.elapsedMs,
+        keyCount: scan.keys.length,
+        queueCount: allQueuesNames.length,
+        scanCount: scan.scanCount,
+      });
+    }
+
+    await mapWithConcurrency(allQueuesNames, QUEUE_INGEST_CONCURRENCY, async (queueName) => {
+      try {
+        const queue = await upsertQueue(queueName);
+        await upsertJobSchedulers(queueName, queue.id);
+      } catch (error) {
+        logger.error(`Error processing queue ${queueName}:`, error);
+      }
+    });
+
+    logger.debug("Queue ingestion completed", {
+      elapsedMs: Date.now() - start,
+      queueCount: allQueuesNames.length,
+    });
   } catch (error) {
     logger.error("Error in queue ingestion:", error);
     throw error;
@@ -75,14 +107,25 @@ export const autoIngestQueues = async () => {
     clearInterval(queueIngestionInterval);
   }
 
-  queueIngestionInterval = setInterval(() => {
-    ingestQueues().catch((error) => {
-      logger.error("Error in queue ingestion:", error);
-    });
-  }, 60_000);
+  const run = async () => {
+    if (queueIngestionRunning) {
+      logger.warn("Skipping queue ingestion tick because previous tick is still running");
+      return;
+    }
 
-  // Run initial ingestion
-  ingestQueues().catch((error) => {
+    queueIngestionRunning = true;
+    try {
+      await ingestQueues();
+    } catch (error) {
+      logger.error("Error in queue ingestion:", error);
+    } finally {
+      queueIngestionRunning = false;
+    }
+  };
+
+  queueIngestionInterval = setInterval(run, 60_000);
+
+  run().catch((error) => {
     logger.error("Error in initial queue ingestion:", error);
   });
 

--- a/apps/ingest/src/repeats/reconcile-jobs.ts
+++ b/apps/ingest/src/repeats/reconcile-jobs.ts
@@ -3,6 +3,7 @@ import { db } from "@better-bull-board/db/server";
 import { logger } from "@rharkor/logger";
 import { type Job, type JobType, Queue } from "bullmq";
 import { and, eq, inArray } from "drizzle-orm";
+import { mapWithConcurrency } from "~/lib/concurrency";
 import { acquireLock, releaseLock } from "~/lib/distributed-lock";
 import { env } from "~/lib/env";
 import { instanceId } from "~/lib/instance";
@@ -12,14 +13,11 @@ import { safeUpsertJobRuns } from "~/sync/job-upsert";
 
 const JOB_TYPES: JobType[] = ["waiting", "active", "delayed", "prioritized", "waiting-children", "completed", "failed"];
 const NON_TERMINAL_STATUSES = ["waiting", "active", "delayed", "prioritized", "waiting-children", "unknown"] as const;
+const JOB_RECONCILE_CONCURRENCY = 5;
 
 let reconcileInterval: NodeJS.Timeout | null = null;
+let reconcileRunning = false;
 let queueCursor = 0;
-
-const inspectUnexpectedJob = (job: unknown) => ({
-  type: typeof job,
-  value: job,
-});
 
 const isBullMqJob = (job: Job | undefined): job is Job => Boolean(job?.id && typeof job.getState === "function");
 
@@ -46,13 +44,10 @@ const reconcileRetainedBullMqJobs = async (queue: Queue, queueName: string) => {
     const jobs = await queue.getJobs(JOB_TYPES, start, start + env.JOB_RECONCILE_PAGE_SIZE - 1, true);
     if (jobs.length === 0) break;
 
+    let unexpectedCount = 0;
     for (const job of jobs) {
       if (!isBullMqJob(job)) {
-        logger.warn("Skipping unexpected BullMQ job during reconciliation", {
-          queueName,
-          start,
-          job: inspectUnexpectedJob(job),
-        });
+        unexpectedCount += 1;
         continue;
       }
 
@@ -66,6 +61,15 @@ const reconcileRetainedBullMqJobs = async (queue: Queue, queueName: string) => {
           state,
         }),
       );
+    }
+
+    if (unexpectedCount > 0) {
+      logger.debug("Skipped unexpected BullMQ jobs during reconciliation", {
+        pageSize: jobs.length,
+        queueName,
+        start,
+        unexpectedCount,
+      });
     }
 
     if (jobs.length < env.JOB_RECONCILE_PAGE_SIZE) break;
@@ -110,6 +114,7 @@ const reconcileMissingNonTerminalRows = async (queue: Queue, queueName: string) 
 };
 
 const reconcileQueue = async (queueName: string) => {
+  const start = Date.now();
   const lockKey = `bbb:job-reconcile-lock:${queueName}`;
   const owner = `${instanceId}:${Date.now()}`;
   const acquired = await acquireLock({ key: lockKey, owner, ttlMs: env.JOB_RECONCILE_INTERVAL_MS * 2 });
@@ -119,6 +124,10 @@ const reconcileQueue = async (queueName: string) => {
   try {
     await reconcileRetainedBullMqJobs(queue, queueName);
     await reconcileMissingNonTerminalRows(queue, queueName);
+    logger.debug("Job reconciliation queue completed", {
+      elapsedMs: Date.now() - start,
+      queueName,
+    });
   } catch (error) {
     logger.error(`Error reconciling queue ${queueName}`, { error });
   } finally {
@@ -128,8 +137,13 @@ const reconcileQueue = async (queueName: string) => {
 };
 
 export const reconcileJobs = async () => {
+  const start = Date.now();
   const queueNames = selectQueueBatch(await getQueueNames());
-  await Promise.all(queueNames.map((queueName) => reconcileQueue(queueName)));
+  await mapWithConcurrency(queueNames, JOB_RECONCILE_CONCURRENCY, reconcileQueue);
+  logger.debug("Job reconciliation tick completed", {
+    elapsedMs: Date.now() - start,
+    queueCount: queueNames.length,
+  });
 };
 
 export const autoReconcileJobs = () => {
@@ -137,13 +151,25 @@ export const autoReconcileJobs = () => {
     clearInterval(reconcileInterval);
   }
 
-  reconcileInterval = setInterval(() => {
-    reconcileJobs().catch((error) => {
-      logger.error("Error in job reconciliation", { error });
-    });
-  }, env.JOB_RECONCILE_INTERVAL_MS);
+  const run = async () => {
+    if (reconcileRunning) {
+      logger.warn("Skipping job reconciliation tick because previous tick is still running");
+      return;
+    }
 
-  reconcileJobs().catch((error) => {
+    reconcileRunning = true;
+    try {
+      await reconcileJobs();
+    } catch (error) {
+      logger.error("Error in job reconciliation", { error });
+    } finally {
+      reconcileRunning = false;
+    }
+  };
+
+  reconcileInterval = setInterval(run, env.JOB_RECONCILE_INTERVAL_MS);
+
+  run().catch((error) => {
     logger.error("Error in initial job reconciliation", { error });
   });
 

--- a/apps/ingest/src/sync/job-stream.ts
+++ b/apps/ingest/src/sync/job-stream.ts
@@ -4,6 +4,7 @@ import { instanceId } from "~/lib/instance";
 import { redis } from "~/lib/redis";
 import { formatJobRun, parseJobSyncEvent } from "./job-format";
 import { safeUpsertJobRuns } from "./job-upsert";
+import { cleanupStaleConsumers } from "./stream-consumers";
 
 const streamRedis = redis.duplicate();
 
@@ -139,6 +140,11 @@ const readNewMessages = async () => {
 
 export const startJobStreamIngestion = async () => {
   await ensureGroup();
+  await cleanupStaleConsumers({
+    client: redis,
+    group: env.JOB_SYNC_CONSUMER_GROUP,
+    stream: env.JOB_SYNC_STREAM_KEY,
+  });
   logger.log("📥 Job stream ingestion started", {
     stream: env.JOB_SYNC_STREAM_KEY,
     group: env.JOB_SYNC_CONSUMER_GROUP,

--- a/apps/ingest/src/sync/log-buffer.ts
+++ b/apps/ingest/src/sync/log-buffer.ts
@@ -24,11 +24,21 @@ type ResolvedLogEvent = LogEventForPersistence & {
 };
 
 let logBufferInterval: NodeJS.Timeout | null = null;
+let resolvedLogInsertChain = Promise.resolve();
 
 const getJobKey = (item: Pick<LogEventForPersistence, "jobId" | "jobTimestamp" | "queue">) =>
   `${item.queue}:${item.jobId}:${item.jobTimestamp.getTime()}`;
 
-async function withDeadlockRetry<T>(fn: () => Promise<T>, tries = 5): Promise<T> {
+const serializeResolvedLogInsert = async <T>(fn: () => Promise<T>) => {
+  const run = resolvedLogInsertChain.then(fn, fn);
+  resolvedLogInsertChain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+};
+
+async function withDeadlockRetry<T>(fn: () => Promise<T>, label: string, tries = 5): Promise<T> {
   let lastErr: unknown;
   for (let i = 0; i < tries; i++) {
     try {
@@ -36,7 +46,13 @@ async function withDeadlockRetry<T>(fn: () => Promise<T>, tries = 5): Promise<T>
     } catch (error: unknown) {
       if (error instanceof DrizzleQueryError && error.cause instanceof DatabaseError && error.cause.code === "40P01") {
         lastErr = error;
+        if (i === tries - 1) break;
         const backoff = 25 * (i + 1) + Math.floor(Math.random() * 50);
+        logger.warn(`Retrying ${label} after Postgres deadlock`, {
+          attempt: i + 1,
+          backoff,
+          maxAttempts: tries,
+        });
         await new Promise((resolve) => setTimeout(resolve, backoff));
         continue;
       }
@@ -92,25 +108,27 @@ const insertResolvedLogs = async (events: ResolvedLogEvent[]) => {
     return a.logSeq - b.logSeq;
   });
 
-  for (let i = 0; i < sorted.length; i += 500) {
-    const chunk = sorted.slice(i, i + 500);
-    await withDeadlockRetry(async () => {
-      await db
-        .insert(jobLogsTable)
-        .values(
-          chunk.map((row) => ({
-            jobRunId: row.jobRunId,
-            level: row.level,
-            message: row.message,
-            ts: row.logTimestamp,
-            logSeq: row.logSeq,
-          })),
-        )
-        .onConflictDoNothing({
-          target: [jobLogsTable.jobRunId, jobLogsTable.ts, jobLogsTable.logSeq],
-        });
-    });
-  }
+  await serializeResolvedLogInsert(async () => {
+    for (let i = 0; i < sorted.length; i += 500) {
+      const chunk = sorted.slice(i, i + 500);
+      await withDeadlockRetry(async () => {
+        await db
+          .insert(jobLogsTable)
+          .values(
+            chunk.map((row) => ({
+              jobRunId: row.jobRunId,
+              level: row.level,
+              message: row.message,
+              ts: row.logTimestamp,
+              logSeq: row.logSeq,
+            })),
+          )
+          .onConflictDoNothing({
+            target: [jobLogsTable.jobRunId, jobLogsTable.ts, jobLogsTable.logSeq],
+          });
+      }, "job_logs insert");
+    }
+  });
 
   for (const jobRunId of new Set(sorted.map((event) => event.jobRunId))) {
     publishIngestEvent("bbb:ingest:events:job-log-refresh", jobRunId, { jobRunId });
@@ -143,7 +161,7 @@ const bufferUnresolvedLogs = async (events: LogEventForPersistence[]) => {
           jobLogBufferTable.logSeq,
         ],
       });
-  });
+  }, "job_log_buffer insert");
 };
 
 export const persistLogEvents = async (events: LogEventForPersistence[]) => {

--- a/apps/ingest/src/sync/log-stream.ts
+++ b/apps/ingest/src/sync/log-stream.ts
@@ -4,6 +4,7 @@ import { env } from "~/lib/env";
 import { instanceId } from "~/lib/instance";
 import { redis } from "~/lib/redis";
 import { persistLogEvents } from "~/sync/log-buffer";
+import { cleanupStaleConsumers } from "~/sync/stream-consumers";
 
 const streamRedis = redis.duplicate();
 
@@ -162,6 +163,11 @@ const readNewMessages = async () => {
 
 export const startJobLogStreamIngestion = async () => {
   await ensureGroup();
+  await cleanupStaleConsumers({
+    client: redis,
+    group: env.JOB_LOG_SYNC_CONSUMER_GROUP,
+    stream: env.JOB_LOG_SYNC_STREAM_KEY,
+  });
   logger.log("📥 Job log stream ingestion started", {
     stream: env.JOB_LOG_SYNC_STREAM_KEY,
     group: env.JOB_LOG_SYNC_CONSUMER_GROUP,

--- a/apps/ingest/src/sync/stream-consumers.ts
+++ b/apps/ingest/src/sync/stream-consumers.ts
@@ -1,0 +1,67 @@
+import { logger } from "@rharkor/logger";
+import type Redis from "ioredis";
+
+const STALE_CONSUMER_IDLE_MS = 60 * 60 * 1000;
+
+type StreamConsumer = {
+  idle: number;
+  name: string;
+  pending: number;
+};
+
+const parseConsumerInfo = (response: unknown): StreamConsumer[] => {
+  if (!Array.isArray(response)) return [];
+
+  return response
+    .map((row): StreamConsumer | undefined => {
+      if (!Array.isArray(row)) return undefined;
+
+      const record = new Map<string, unknown>();
+      for (let i = 0; i < row.length; i += 2) {
+        record.set(String(row[i]), row[i + 1]);
+      }
+
+      const name = record.get("name");
+      const idle = Number(record.get("idle"));
+      const pending = Number(record.get("pending"));
+
+      if (typeof name !== "string" || Number.isNaN(idle) || Number.isNaN(pending)) return undefined;
+      return { idle, name, pending };
+    })
+    .filter((consumer): consumer is StreamConsumer => Boolean(consumer));
+};
+
+export const cleanupStaleConsumers = async ({
+  client,
+  group,
+  stream,
+}: {
+  client: Redis;
+  group: string;
+  stream: string;
+}) => {
+  try {
+    const response = await client.call("XINFO", "CONSUMERS", stream, group);
+    const staleConsumers = parseConsumerInfo(response).filter(
+      (consumer) => consumer.pending === 0 && consumer.idle >= STALE_CONSUMER_IDLE_MS,
+    );
+
+    for (const consumer of staleConsumers) {
+      await client.call("XGROUP", "DELCONSUMER", stream, group, consumer.name);
+    }
+
+    if (staleConsumers.length > 0) {
+      logger.debug("Removed stale Redis stream consumers", {
+        group,
+        removed: staleConsumers.length,
+        stream,
+      });
+    }
+  } catch (error) {
+    logger.warn("Failed to clean up stale Redis stream consumers", {
+      error,
+      group,
+      stream,
+    });
+  }
+};

--- a/k8s/05-ingest.yaml
+++ b/k8s/05-ingest.yaml
@@ -29,15 +29,15 @@ spec:
                 name: bbb-ingest-secret
           livenessProbe:
             httpGet:
-              path: /health
+              path: /live
               port: 3001
             initialDelaySeconds: 30
             periodSeconds: 10
-            timeoutSeconds: 10
+            timeoutSeconds: 3
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /health
+              path: /ready
               port: 3001
             initialDelaySeconds: 15
             periodSeconds: 5


### PR DESCRIPTION
Reduce ingester restarts under load by separating process liveness from dependency readiness and limiting repeat-task work that can accumulate while the event loop is under pressure.

**Restart resilience**

The Kubernetes liveness probe now checks a lightweight /live endpoint, while /ready and /health continue to verify Redis and Postgres with short internal timeouts. This prevents transient dependency stalls from turning into liveness failures when the process is still running.

**Ingestion pressure and deadlocks**

Queue ingestion and job reconciliation now skip overlapping ticks, process queues with bounded concurrency, and emit timing logs. Resolved job log inserts are serialized inside the ingester process, deadlock retry logs identify the insert path, and stale Redis stream consumers are cleaned up when stream ingestion starts.

**Debug visibility**

Repeat jobs now log completion timings and incomplete Redis scans avoid deleting missing queues, making it easier to separate dependency latency from actual process failures.