### PR TITLE
perf(ingest): Reduce reconciliation lock pressure

### DIFF
--- a/apps/ingest/src/repeats/reconcile-jobs.ts
+++ b/apps/ingest/src/repeats/reconcile-jobs.ts
@@ -8,10 +8,10 @@ import { acquireLock, releaseLock } from "~/lib/distributed-lock";
 import { env } from "~/lib/env";
 import { instanceId } from "~/lib/instance";
 import { redis } from "~/lib/redis";
-import { bullStateToPersistedStatus, formatJobRun, isTerminalStatus, type JobRunInsert } from "~/sync/job-format";
+import { bullStateToPersistedStatus, formatJobRun, type JobRunInsert } from "~/sync/job-format";
 import { safeUpsertJobRuns } from "~/sync/job-upsert";
 
-const JOB_TYPES: JobType[] = ["waiting", "active", "delayed", "prioritized", "waiting-children", "completed", "failed"];
+const JOB_TYPES: JobType[] = ["waiting", "active", "delayed", "prioritized", "waiting-children"];
 const NON_TERMINAL_STATUSES = ["waiting", "active", "delayed", "prioritized", "waiting-children", "unknown"] as const;
 const JOB_RECONCILE_CONCURRENCY = 5;
 
@@ -106,7 +106,6 @@ const reconcileMissingNonTerminalRows = async (queue: Queue, queueName: string) 
       continue;
     }
 
-    if (isTerminalStatus(row.status)) continue;
     await db.update(jobRunsTable).set({ status: "unknown" }).where(eq(jobRunsTable.id, row.id));
     await redis.publish("bbb:ingest:events:single-job-refresh", row.id);
     await redis.publish("bbb:ingest:events:job-refresh", "1");

--- a/apps/ingest/src/sync/log-buffer.ts
+++ b/apps/ingest/src/sync/log-buffer.ts
@@ -99,11 +99,17 @@ const insertResolvedLogs = async (events: ResolvedLogEvent[]) => {
   if (events.length === 0) return;
 
   const sorted = [...events].sort((a, b) => {
-    const runCompare = a.jobRunId.localeCompare(b.jobRunId);
-    if (runCompare !== 0) return runCompare;
+    const queueCompare = a.queue.localeCompare(b.queue);
+    if (queueCompare !== 0) return queueCompare;
 
-    const timestampCompare = a.logTimestamp.getTime() - b.logTimestamp.getTime();
-    if (timestampCompare !== 0) return timestampCompare;
+    const jobCompare = a.jobId.localeCompare(b.jobId);
+    if (jobCompare !== 0) return jobCompare;
+
+    const jobTimestampCompare = a.jobTimestamp.getTime() - b.jobTimestamp.getTime();
+    if (jobTimestampCompare !== 0) return jobTimestampCompare;
+
+    const logTimestampCompare = a.logTimestamp.getTime() - b.logTimestamp.getTime();
+    if (logTimestampCompare !== 0) return logTimestampCompare;
 
     return a.logSeq - b.logSeq;
   });


### PR DESCRIPTION
Reduce database lock pressure in the ingester by narrowing reconciliation to non-terminal BullMQ jobs and aligning log insert ordering with the parent job identity.

**Reconciliation Scope**

Reconciliation no longer scans retained completed and failed BullMQ jobs on every tick. It now focuses on non-terminal states, which avoids repeatedly upserting historical terminal runs while still correcting active, waiting, delayed, prioritized, waiting-child, and unknown jobs.

**Log Insert Ordering**

Resolved job logs now sort by queue, job id, job timestamp, log timestamp, and sequence before insert. This better matches the parent job_runs conflict key order and should reduce foreign-key lock inversions between job_logs inserts and job_runs upserts.