### PR TITLE
feat(runs): Support opening run rows in new tabs

### DIFF
--- a/apps/app/src/app/runs/_components/runs-table.tsx
+++ b/apps/app/src/app/runs/_components/runs-table.tsx
@@ -191,8 +191,29 @@ export function RunsTable() {
     }
   };
 
-  const handleRowClick = (runId: string) => {
-    router.push(`/runs/${runId}`);
+  const isInteractiveRowTarget = (target: EventTarget | null) =>
+    target instanceof Element && !!target.closest("a,button,input,select,textarea,[role='checkbox']");
+
+  const openRunInNewPage = (runPath: string) => {
+    window.open(runPath, "_blank", "noopener,noreferrer");
+  };
+
+  const handleRowClick = (event: React.MouseEvent<HTMLTableRowElement>, runPath: string) => {
+    if (isInteractiveRowTarget(event.target)) return;
+
+    if (event.metaKey || event.ctrlKey) {
+      openRunInNewPage(runPath);
+      return;
+    }
+
+    router.push(runPath);
+  };
+
+  const handleRowAuxClick = (event: React.MouseEvent<HTMLTableRowElement>, runPath: string) => {
+    if (event.button !== 1 || isInteractiveRowTarget(event.target)) return;
+
+    event.preventDefault();
+    openRunInNewPage(runPath);
   };
 
   const handleDurationSort = () => {
@@ -254,87 +275,92 @@ export function RunsTable() {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {jobs.map((run) => (
-              <AnimatePresence key={`${run.id}-${run.createdAt.getTime()}`}>
-                <motion.tr
-                  key={run.id}
-                  className={cn(
-                    "group border-b transition-colors hover:bg-muted/50 cursor-pointer",
-                    selectedJobIds.has(run.jobId) && "bg-blue-50 dark:bg-blue-950",
-                  )}
-                  initial={{ opacity: 0, y: -100 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.15, ease: "easeOut" }}
-                  layoutId={run.id}
-                  onClick={() => handleRowClick(run.id)}
-                >
-                  <TableCell>
-                    <div className="flex items-center">
-                      <Checkbox
-                        checked={selectedJobIds.has(run.jobId)}
-                        onCheckedChange={(checked) => handleSelectJob(run.jobId, checked as boolean)}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                        }}
-                        aria-label={`Select job ${run.jobId}`}
-                      />
-                    </div>
-                  </TableCell>
-                  <TableCell className="font-mono text-xs">
-                    {run.jobId.slice(0, 32)}
-                    {run.jobId.length > 32 && "..."}
-                  </TableCell>
-                  <TableCell className="truncate">{run.queue}</TableCell>
-                  <TableCell className="overflow-hidden">
-                    {run.tags?.map((tag) => (
-                      <Badge key={tag} variant="outline">
-                        {tag}
-                      </Badge>
-                    ))}
-                  </TableCell>
-                  <TableCell>
-                    <Badge className={getStatusColor(run.status)}>{run.status}</Badge>
-                  </TableCell>
-                  <TableCell>
-                    {run.startedAt && run.finishedAt && (run.status === "completed" || run.status === "failed")
-                      ? formatDistanceStrict(run.startedAt, run.finishedAt)
-                      : "-"}
-                  </TableCell>
-                  <TableCell className="truncate">
-                    <time dateTime={run.createdAt.toISOString()} title={run.createdAt.toLocaleString()}>
-                      <span className="block truncate">{formatRunTimestamp(run.createdAt).relative}</span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {formatRunTimestamp(run.createdAt).absolute}
-                      </span>
-                    </time>
-                  </TableCell>
-                  <TableCell className="truncate">
-                    {run.finishedAt ? (
-                      <time dateTime={run.finishedAt.toISOString()} title={run.finishedAt.toLocaleString()}>
-                        <span className="block truncate">{formatRunTimestamp(run.finishedAt).relative}</span>
+            {jobs.map((run) => {
+              const runPath = `/runs/${run.id}`;
+
+              return (
+                <AnimatePresence key={`${run.id}-${run.createdAt.getTime()}`}>
+                  <motion.tr
+                    key={run.id}
+                    className={cn(
+                      "group border-b transition-colors hover:bg-muted/50 cursor-pointer",
+                      selectedJobIds.has(run.jobId) && "bg-blue-50 dark:bg-blue-950",
+                    )}
+                    initial={{ opacity: 0, y: -100 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.15, ease: "easeOut" }}
+                    layoutId={run.id}
+                    onClick={(event) => handleRowClick(event, runPath)}
+                    onAuxClick={(event) => handleRowAuxClick(event, runPath)}
+                  >
+                    <TableCell>
+                      <div className="flex items-center">
+                        <Checkbox
+                          checked={selectedJobIds.has(run.jobId)}
+                          onCheckedChange={(checked) => handleSelectJob(run.jobId, checked as boolean)}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                          }}
+                          aria-label={`Select job ${run.jobId}`}
+                        />
+                      </div>
+                    </TableCell>
+                    <TableCell className="font-mono text-xs">
+                      {run.jobId.slice(0, 32)}
+                      {run.jobId.length > 32 && "..."}
+                    </TableCell>
+                    <TableCell className="truncate">{run.queue}</TableCell>
+                    <TableCell className="overflow-hidden">
+                      {run.tags?.map((tag) => (
+                        <Badge key={tag} variant="outline">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </TableCell>
+                    <TableCell>
+                      <Badge className={getStatusColor(run.status)}>{run.status}</Badge>
+                    </TableCell>
+                    <TableCell>
+                      {run.startedAt && run.finishedAt && (run.status === "completed" || run.status === "failed")
+                        ? formatDistanceStrict(run.startedAt, run.finishedAt)
+                        : "-"}
+                    </TableCell>
+                    <TableCell className="truncate">
+                      <time dateTime={run.createdAt.toISOString()} title={run.createdAt.toLocaleString()}>
+                        <span className="block truncate">{formatRunTimestamp(run.createdAt).relative}</span>
                         <span className="block truncate text-xs text-muted-foreground">
-                          {formatRunTimestamp(run.finishedAt).absolute}
+                          {formatRunTimestamp(run.createdAt).absolute}
                         </span>
                       </time>
-                    ) : (
-                      "-"
-                    )}
-                  </TableCell>
-                  <TableCell
-                    className={cn("max-w-48 truncate text-xs", {
-                      "text-red-600": run.status === "failed" && run.errorMessage,
-                    })}
-                  >
-                    {run.status === "failed" && run.errorMessage ? run.errorMessage : "-"}
-                  </TableCell>
-                  <TableCell onClick={(e) => e.stopPropagation()}>
-                    <div className="opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                      <RunActions jobId={run.jobId} queueName={run.queue} status={run.status} />
-                    </div>
-                  </TableCell>
-                </motion.tr>
-              </AnimatePresence>
-            ))}
+                    </TableCell>
+                    <TableCell className="truncate">
+                      {run.finishedAt ? (
+                        <time dateTime={run.finishedAt.toISOString()} title={run.finishedAt.toLocaleString()}>
+                          <span className="block truncate">{formatRunTimestamp(run.finishedAt).relative}</span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {formatRunTimestamp(run.finishedAt).absolute}
+                          </span>
+                        </time>
+                      ) : (
+                        "-"
+                      )}
+                    </TableCell>
+                    <TableCell
+                      className={cn("max-w-48 truncate text-xs", {
+                        "text-red-600": run.status === "failed" && run.errorMessage,
+                      })}
+                    >
+                      {run.status === "failed" && run.errorMessage ? run.errorMessage : "-"}
+                    </TableCell>
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      <div className="opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                        <RunActions jobId={run.jobId} queueName={run.queue} status={run.status} />
+                      </div>
+                    </TableCell>
+                  </motion.tr>
+                </AnimatePresence>
+              );
+            })}
           </TableBody>
         </Table>
       </div>


### PR DESCRIPTION
Run table rows now support middle-click and Cmd/Ctrl-click to open the run detail page in a new tab while keeping the existing same-page click behavior.

**Row Navigation**

The table still uses row-level navigation to match the app's current table conventions. Interactive cells such as selection checkboxes and run actions are ignored so they do not accidentally trigger navigation.