### PR TITLE
fix(runs): Use UTC for created date filters

### DIFF
--- a/apps/app/src/app/api/jobs/table/route.ts
+++ b/apps/app/src/app/api/jobs/table/route.ts
@@ -37,7 +37,9 @@ const parseCreatedBoundary = ({
   isUpperBoundary?: boolean;
   value: string;
 }) => {
-  const date = new Date(value.includes("T") ? value : `${value}T${fallbackTime}`);
+  const valueWithTime = value.includes("T") ? value : `${value}T${fallbackTime}`;
+  const hasTimezone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(valueWithTime);
+  const date = new Date(hasTimezone ? valueWithTime : `${valueWithTime}Z`);
 
   if (isUpperBoundary && /T\d{2}:\d{2}$/.test(value)) {
     date.setSeconds(59, 999);

--- a/apps/app/src/app/runs/_components/runs-table.tsx
+++ b/apps/app/src/app/runs/_components/runs-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { format, formatDistanceStrict, formatDistanceToNowStrict } from "date-fns";
+import { formatDistanceStrict, formatDistanceToNowStrict } from "date-fns";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -29,10 +29,27 @@ const parseAsCursor = createParser<NonNullable<TRunFilters["cursor"]>>({
   serialize: (value) => Buffer.from(JSON.stringify(value)).toString("base64"),
 });
 
+const formatUtcTimestamp = (value: Date) => `${value.toISOString().slice(0, 19).replace("T", " ")} UTC`;
+
 const formatRunTimestamp = (value: Date) => ({
-  absolute: format(value, "MMM d, yyyy HH:mm:ss"),
+  absolute: formatUtcTimestamp(value),
   relative: formatDistanceToNowStrict(value, { addSuffix: true }),
 });
+
+type RunTimestampProps = {
+  value: Date;
+};
+
+function RunTimestamp({ value }: RunTimestampProps) {
+  const timestamp = formatRunTimestamp(value);
+
+  return (
+    <time dateTime={value.toISOString()} title={timestamp.absolute}>
+      <span className="block truncate">{timestamp.relative}</span>
+      <span className="block truncate text-xs text-muted-foreground">{timestamp.absolute}</span>
+    </time>
+  );
+}
 
 export function RunsTable() {
   const router = useRouter();
@@ -247,8 +264,8 @@ export function RunsTable() {
                   {getDurationSortIcon()}
                 </button>
               </TableHead>
-              <TableHead style={{ width: "140px" }}>Created</TableHead>
-              <TableHead style={{ width: "140px" }}>Finished</TableHead>
+              <TableHead style={{ width: "170px" }}>Created</TableHead>
+              <TableHead style={{ width: "170px" }}>Finished</TableHead>
               <TableHead style={{ width: "140px" }}>Error</TableHead>
               <TableHead style={{ width: "90px" }}>Actions</TableHead>
             </TableRow>
@@ -301,21 +318,11 @@ export function RunsTable() {
                       : "-"}
                   </TableCell>
                   <TableCell className="truncate">
-                    <time dateTime={run.createdAt.toISOString()} title={run.createdAt.toLocaleString()}>
-                      <span className="block truncate">{formatRunTimestamp(run.createdAt).relative}</span>
-                      <span className="block truncate text-xs text-muted-foreground">
-                        {formatRunTimestamp(run.createdAt).absolute}
-                      </span>
-                    </time>
+                    <RunTimestamp value={run.createdAt} />
                   </TableCell>
                   <TableCell className="truncate">
                     {run.finishedAt ? (
-                      <time dateTime={run.finishedAt.toISOString()} title={run.finishedAt.toLocaleString()}>
-                        <span className="block truncate">{formatRunTimestamp(run.finishedAt).relative}</span>
-                        <span className="block truncate text-xs text-muted-foreground">
-                          {formatRunTimestamp(run.finishedAt).absolute}
-                        </span>
-                      </time>
+                      <RunTimestamp value={run.finishedAt} />
                     ) : (
                       "-"
                     )}


### PR DESCRIPTION
Created date filters on the runs queue page now treat timezone-less picker values as UTC, preventing local server timezone shifts from changing the queried window. The runs table also shows explicit UTC timestamps below the relative created and finished times, matching the app's existing ISO-derived timestamp style.

**UTC Date Filtering**

The jobs table API preserves explicit timezone offsets and appends UTC only for timezone-less datetime-local values.

**Runs Table Timestamps**

Created and finished columns keep the relative time as the primary display and add a secondary UTC timestamp for exact inspection.