### PR TITLE
feat(queues): Add queue count sorting

### DIFF
--- a/apps/app/src/app/api/queues/table/route.ts
+++ b/apps/app/src/app/api/queues/table/route.ts
@@ -6,7 +6,9 @@ import { createAuthenticatedApiRoute } from "~/lib/utils/server";
 import { getQueuesTableApiRoute } from "./schemas";
 
 type CursorDirection = "next" | "prev";
-type QueueCursor = { waitingJobs: number; name: string };
+type QueueSortBy = "waitingJobs" | "activeJobs";
+type SortDirection = "asc" | "desc";
+type QueueCursor = { waitingJobs: number; activeJobs?: number; name: string };
 
 const waitingJobCounts = db
   .select({
@@ -20,26 +22,60 @@ const waitingJobCounts = db
 
 const waitingJobsExpression = sql<number>`COALESCE(${waitingJobCounts.waitingJobs}, 0)`;
 
-const getCursorComparison = (cursor: QueueCursor, direction: CursorDirection) => {
-  if (direction === "prev") {
-    return or(
-      gt(waitingJobsExpression, cursor.waitingJobs),
-      and(eq(waitingJobsExpression, cursor.waitingJobs), lt(queuesTable.name, cursor.name)),
-    );
-  }
+const activeJobCounts = db
+  .select({
+    queue: jobRunsTable.queue,
+    activeJobs: sql<number>`COUNT(*)::int`.as("active_jobs"),
+  })
+  .from(jobRunsTable)
+  .where(eq(jobRunsTable.status, "active"))
+  .groupBy(jobRunsTable.queue)
+  .as("active_job_counts");
 
-  return or(
-    lt(waitingJobsExpression, cursor.waitingJobs),
-    and(eq(waitingJobsExpression, cursor.waitingJobs), gt(queuesTable.name, cursor.name)),
-  );
+const activeJobsExpression = sql<number>`COALESCE(${activeJobCounts.activeJobs}, 0)`;
+
+const getSortExpression = (sortBy: QueueSortBy) => {
+  if (sortBy === "activeJobs") return activeJobsExpression;
+  return waitingJobsExpression;
 };
 
-const getSortOrder = (direction: CursorDirection) => {
-  if (direction === "prev") {
-    return [asc(waitingJobsExpression), desc(queuesTable.name)];
+const getCursorValue = (cursor: QueueCursor, sortBy: QueueSortBy) => {
+  if (sortBy === "activeJobs") return cursor.activeJobs ?? 0;
+  return cursor.waitingJobs;
+};
+
+const getOrderDirection = (cursorDirection: CursorDirection, sortDirection: SortDirection) => {
+  if (cursorDirection === "next") return sortDirection;
+  return sortDirection === "desc" ? "asc" : "desc";
+};
+
+const getCursorComparison = (
+  cursor: QueueCursor,
+  cursorDirection: CursorDirection,
+  sortBy: QueueSortBy,
+  sortDirection: SortDirection,
+) => {
+  const sortExpression = getSortExpression(sortBy);
+  const cursorValue = getCursorValue(cursor, sortBy);
+  const nameComparison =
+    cursorDirection === "next" ? gt(queuesTable.name, cursor.name) : lt(queuesTable.name, cursor.name);
+  const tiedSortComparison = and(eq(sortExpression, cursorValue), nameComparison);
+  const shouldUseGreaterThan = cursorDirection === "next" ? sortDirection === "asc" : sortDirection === "desc";
+
+  if (shouldUseGreaterThan) {
+    return or(gt(sortExpression, cursorValue), tiedSortComparison);
   }
 
-  return [desc(waitingJobsExpression), asc(queuesTable.name)];
+  return or(lt(sortExpression, cursorValue), tiedSortComparison);
+};
+
+const getSortOrder = (cursorDirection: CursorDirection, sortBy: QueueSortBy, sortDirection: SortDirection) => {
+  const sortExpression = getSortExpression(sortBy);
+  const orderDirection = getOrderDirection(cursorDirection, sortDirection);
+  const sortOrder = orderDirection === "asc" ? asc(sortExpression) : desc(sortExpression);
+  const nameOrder = cursorDirection === "next" ? asc(queuesTable.name) : desc(queuesTable.name);
+
+  return [sortOrder, nameOrder];
 };
 
 function fillChartData(
@@ -78,7 +114,7 @@ function fillChartData(
 export const POST = createAuthenticatedApiRoute({
   apiRoute: getQueuesTableApiRoute,
   async handler(input) {
-    const { search, timePeriod } = input;
+    const { search, timePeriod, sortBy, sortDirection } = input;
     const cursorDirection = input.cursorDirection ?? "next";
     const cursor = input.cursor;
     const limit = input.limit ?? 20;
@@ -90,20 +126,22 @@ export const POST = createAuthenticatedApiRoute({
           name: queuesTable.name,
           isPaused: queuesTable.isPaused,
           waitingJobs: waitingJobsExpression.as("waiting_jobs"),
+          activeJobs: activeJobsExpression.as("active_jobs"),
           patterns: sql<string[] | null | undefined>`array_agg(${jobSchedulersTable.pattern})`.as("patterns"),
           everys: sql<number[] | null | undefined>`array_agg(${jobSchedulersTable.every})`.as("everys"),
         })
         .from(queuesTable)
         .leftJoin(waitingJobCounts, eq(waitingJobCounts.queue, queuesTable.name))
+        .leftJoin(activeJobCounts, eq(activeJobCounts.queue, queuesTable.name))
         .leftJoin(jobSchedulersTable, eq(jobSchedulersTable.queueId, queuesTable.id))
         .where(
           and(
-            cursor ? getCursorComparison(cursor, direction) : undefined,
+            cursor ? getCursorComparison(cursor, direction, sortBy, sortDirection) : undefined,
             search ? ilike(queuesTable.name, `%${search}%`) : undefined,
           ),
         )
-        .groupBy(queuesTable.id, waitingJobCounts.waitingJobs)
-        .orderBy(...getSortOrder(direction))
+        .groupBy(queuesTable.id, waitingJobCounts.waitingJobs, activeJobCounts.activeJobs)
+        .orderBy(...getSortOrder(direction, sortBy, sortDirection))
         .limit(limit + 1);
     };
 
@@ -261,8 +299,22 @@ export const POST = createAuthenticatedApiRoute({
           chartData: stats.chartData,
         };
       }),
-      nextCursor: hasOlderPage && lastRow ? { name: lastRow.name, waitingJobs: Number(lastRow.waitingJobs) } : null,
-      prevCursor: hasNewerPage && firstRow ? { name: firstRow.name, waitingJobs: Number(firstRow.waitingJobs) } : null,
+      nextCursor:
+        hasOlderPage && lastRow
+          ? {
+              name: lastRow.name,
+              waitingJobs: Number(lastRow.waitingJobs),
+              activeJobs: Number(lastRow.activeJobs),
+            }
+          : null,
+      prevCursor:
+        hasNewerPage && firstRow
+          ? {
+              name: firstRow.name,
+              waitingJobs: Number(firstRow.waitingJobs),
+              activeJobs: Number(firstRow.activeJobs),
+            }
+          : null,
       total: Number(total?.count ?? 0),
     };
   },

--- a/apps/app/src/app/api/queues/table/schemas.ts
+++ b/apps/app/src/app/api/queues/table/schemas.ts
@@ -5,12 +5,15 @@ export const getQueuesTableInput = z.object({
   cursor: z
     .object({
       waitingJobs: z.number(),
+      activeJobs: z.number().optional(),
       name: z.string(),
     })
     .nullish(),
   cursorDirection: z.enum(["next", "prev"]).optional(),
   search: z.string().optional(),
   timePeriod: z.enum(["1", "3", "7", "30"]).optional().default("1"),
+  sortBy: z.enum(["waitingJobs", "activeJobs"]).optional().default("waitingJobs"),
+  sortDirection: z.enum(["asc", "desc"]).optional().default("desc"),
   limit: z.number().min(1).max(100).optional(),
 });
 
@@ -36,12 +39,14 @@ export const getQueuesTableOutput = z.object({
   nextCursor: z
     .object({
       waitingJobs: z.number(),
+      activeJobs: z.number(),
       name: z.string(),
     })
     .nullable(),
   prevCursor: z
     .object({
       waitingJobs: z.number(),
+      activeJobs: z.number(),
       name: z.string(),
     })
     .nullable(),

--- a/apps/app/src/app/queues/_components/queues-table.tsx
+++ b/apps/app/src/app/queues/_components/queues-table.tsx
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { formatDuration } from "date-fns";
 import { AnimatePresence, motion } from "framer-motion";
-import { ChevronLeft, ChevronRight, Search } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, ChevronLeft, ChevronRight, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { createParser, parseAsString, useQueryStates } from "nuqs";
 import { getQueuesTableApiRoute } from "~/app/api/queues/table/schemas";
@@ -17,7 +17,14 @@ import { QueueActions } from "./queue-actions";
 import { QueueMiniChart } from "./queue-mini-chart";
 import { type TimePeriod, TimePeriodSelector } from "./time-period-selector";
 
-type QueueCursor = { waitingJobs: number; name: string };
+type QueueCursor = { waitingJobs: number; activeJobs?: number; name: string };
+type SortBy = "waitingJobs" | "activeJobs";
+type SortDirection = "asc" | "desc";
+
+const sortableQueueColumns: { key: SortBy; label: string }[] = [
+  { key: "waitingJobs", label: "Waiting Jobs" },
+  { key: "activeJobs", label: "Active Jobs" },
+];
 
 const parseAsCursor = createParser<QueueCursor>({
   parse: (value) => {
@@ -37,13 +44,19 @@ export function QueuesTable() {
     timePeriod: parseAsString.withDefault("1"),
     cursor: parseAsCursor,
     cursorDirection: parseAsString.withDefault("next"),
+    sortBy: parseAsString.withDefault("waitingJobs"),
+    sortDirection: parseAsString.withDefault("desc"),
   });
 
   const cursorDirection: "next" | "prev" = urlState.cursorDirection === "prev" ? "prev" : "next";
+  const sortBy: SortBy = urlState.sortBy === "activeJobs" ? "activeJobs" : "waitingJobs";
+  const sortDirection: SortDirection = urlState.sortDirection === "asc" ? "asc" : "desc";
   const options = {
     cursor: urlState.cursor,
     cursorDirection,
     search: urlState.search,
+    sortBy,
+    sortDirection,
     timePeriod: urlState.timePeriod as TimePeriod,
   };
 
@@ -81,6 +94,21 @@ export function QueuesTable() {
   const handleTimePeriodChange = (timePeriod: TimePeriod) => {
     // Reset pagination when time period changes
     setUrlState({ cursor: null, cursorDirection: "next", timePeriod });
+  };
+
+  const handleSort = (nextSortBy: SortBy) => {
+    setUrlState({
+      cursor: null,
+      cursorDirection: "next",
+      sortBy: nextSortBy,
+      sortDirection: sortBy === nextSortBy && sortDirection === "desc" ? "asc" : "desc",
+    });
+  };
+
+  const getSortIcon = (key: SortBy) => {
+    if (sortBy !== key) return <ArrowUpDown className="size-3.5 text-muted-foreground" />;
+    if (sortDirection === "asc") return <ArrowUp className="size-3.5" />;
+    return <ArrowDown className="size-3.5" />;
   };
 
   const selectedQueueStats = data?.queues.length === 1 ? data.queues[0] : undefined;
@@ -134,8 +162,18 @@ export function QueuesTable() {
               <TableHead style={{ width: "200px" }}>Queue Name</TableHead>
               <TableHead style={{ width: "120px" }}>Status</TableHead>
               <TableHead style={{ width: "120px" }}>Scheduler</TableHead>
-              <TableHead style={{ width: "120px" }}>Waiting Jobs</TableHead>
-              <TableHead style={{ width: "120px" }}>Active Jobs</TableHead>
+              {sortableQueueColumns.map((column) => (
+                <TableHead key={column.key} style={{ width: "120px" }}>
+                  <button
+                    type="button"
+                    className="flex items-center gap-1 font-medium"
+                    onClick={() => handleSort(column.key)}
+                  >
+                    {column.label}
+                    {getSortIcon(column.key)}
+                  </button>
+                </TableHead>
+              ))}
               <TableHead style={{ width: "240px" }}>Pressure</TableHead>
               <TableHead style={{ width: "70px" }}>Trend</TableHead>
               <TableHead style={{ width: "90px" }}></TableHead>


### PR DESCRIPTION
Queues can now be sorted by waiting or active job counts from the queues table headers, matching the arrow-button pattern used in Queue Performance Summary. Sorting state is reflected in the URL and resets pagination when changed.

**Queue Table Sorting**

The Waiting Jobs and Active Jobs headers now toggle ascending and descending order with the same icon states used by the dashboard performance table.

**Keyset Pagination**

The queues table API accepts sort field and direction inputs, includes active job counts in cursors, and applies queue-name tie breakers so next/previous pagination remains stable across both sortable count columns.