### PR TITLE
fix(dashboard): Count live queue stats from job runs

### DIFF
--- a/apps/app/src/app/api/dashboard/summary/handler.ts
+++ b/apps/app/src/app/api/dashboard/summary/handler.ts
@@ -1,4 +1,4 @@
-import { dashboardQueueHourlyStatsTable } from "@better-bull-board/db";
+import { dashboardQueueHourlyStatsTable, jobRunsTable } from "@better-bull-board/db";
 import { db } from "@better-bull-board/db/server";
 import { addDays, addHours, startOfDay, startOfHour } from "date-fns";
 import { sql } from "drizzle-orm";
@@ -56,11 +56,21 @@ const getDashboardWindow = (days: number): DashboardWindow => {
 const getStats = async ({ bucketFrom, dateTo }: DashboardWindow) => {
   const result = await db.execute(sql`
       SELECT
-        COALESCE(SUM("active_runs"), 0)::bigint AS "running_tasks",
-        COALESCE(SUM("waiting_runs"), 0)::bigint AS "waiting_in_queue",
-        COALESCE(SUM("completed_runs") FILTER (WHERE "bucket_start" >= ${bucketFrom} AND "bucket_start" <= ${dateTo}), 0)::bigint AS "successes",
-        COALESCE(SUM("failed_runs") FILTER (WHERE "bucket_start" >= ${bucketFrom} AND "bucket_start" <= ${dateTo}), 0)::bigint AS "failures"
+        (
+          SELECT COUNT(*)
+          FROM ${jobRunsTable}
+          WHERE ${jobRunsTable.status} = 'active'
+        )::bigint AS "running_tasks",
+        (
+          SELECT COUNT(*)
+          FROM ${jobRunsTable}
+          WHERE ${jobRunsTable.status} = 'waiting'
+        )::bigint AS "waiting_in_queue",
+        COALESCE(SUM("completed_runs"), 0)::bigint AS "successes",
+        COALESCE(SUM("failed_runs"), 0)::bigint AS "failures"
       FROM ${dashboardQueueHourlyStatsTable}
+      WHERE "bucket_start" >= ${bucketFrom}
+        AND "bucket_start" <= ${dateTo}
     `);
   const stats = (result.rows as StatsRow[])[0];
 


### PR DESCRIPTION
Count the dashboard's live queue cards from current job run statuses instead of accumulated hourly rollups.

The Running Tasks and Waiting in Queue cards now match the live semantics used by the queue table. Successes and Failures still use the selected dashboard time window from the hourly rollups, so changing the time filter only affects historical completion and failure totals.