### PR TITLE
fix(db): Make pending migrations idempotent

### DIFF
--- a/packages/db/drizzle/0015_job_log_buffer.sql
+++ b/packages/db/drizzle/0015_job_log_buffer.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "job_log_buffer" (
+CREATE TABLE IF NOT EXISTS "job_log_buffer" (
 	"id" uuid PRIMARY KEY DEFAULT uuid_generate_v7() NOT NULL,
 	"queue" text NOT NULL,
 	"job_id" text NOT NULL,
@@ -9,6 +9,6 @@ CREATE TABLE "job_log_buffer" (
 	"message" text NOT NULL,
 	"created_at" timestamp (3) DEFAULT CURRENT_TIMESTAMP NOT NULL
 );--> statement-breakpoint
-CREATE UNIQUE INDEX "ux_job_log_buffer_identity" ON "job_log_buffer" USING btree ("queue","job_id","job_timestamp","log_timestamp","log_seq");--> statement-breakpoint
-CREATE INDEX "ix_job_log_buffer_created_at" ON "job_log_buffer" USING btree ("created_at");--> statement-breakpoint
-CREATE INDEX "ix_job_log_buffer_job" ON "job_log_buffer" USING btree ("queue","job_id","job_timestamp");
+CREATE UNIQUE INDEX IF NOT EXISTS "ux_job_log_buffer_identity" ON "job_log_buffer" USING btree ("queue","job_id","job_timestamp","log_timestamp","log_seq");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ix_job_log_buffer_created_at" ON "job_log_buffer" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ix_job_log_buffer_job" ON "job_log_buffer" USING btree ("queue","job_id","job_timestamp");

--- a/packages/db/drizzle/0016_job_runs_keyset_indexes.sql
+++ b/packages/db/drizzle/0016_job_runs_keyset_indexes.sql
@@ -1,5 +1,5 @@
-CREATE INDEX "ix_job_runs_created_at_job_id_id" ON "job_runs" USING btree ("created_at","job_id","id");--> statement-breakpoint
-CREATE INDEX "ix_job_runs_queue_created_at_job_id_id" ON "job_runs" USING btree ("queue","created_at","job_id","id");--> statement-breakpoint
-CREATE INDEX "ix_job_runs_status_created_at_job_id_id" ON "job_runs" USING btree ("status","created_at","job_id","id");--> statement-breakpoint
-CREATE INDEX "ix_job_runs_queue_status_created_at_job_id_id" ON "job_runs" USING btree ("queue","status","created_at","job_id","id");--> statement-breakpoint
-CREATE INDEX "ix_job_runs_duration_created_at_job_id_id" ON "job_runs" USING btree (COALESCE("duration_ms", 0),"created_at","job_id","id");
+CREATE INDEX IF NOT EXISTS "ix_job_runs_created_at_job_id_id" ON "job_runs" USING btree ("created_at","job_id","id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ix_job_runs_queue_created_at_job_id_id" ON "job_runs" USING btree ("queue","created_at","job_id","id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ix_job_runs_status_created_at_job_id_id" ON "job_runs" USING btree ("status","created_at","job_id","id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ix_job_runs_queue_status_created_at_job_id_id" ON "job_runs" USING btree ("queue","status","created_at","job_id","id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ix_job_runs_duration_created_at_job_id_id" ON "job_runs" USING btree (COALESCE("duration_ms", 0),"created_at","job_id","id");


### PR DESCRIPTION
Make the pending job log buffer and keyset index migrations tolerate databases where those objects already exist but Drizzle has not recorded the migration rows yet. This lets migration bookkeeping catch up instead of failing on duplicate tables or indexes.

**Migration Safety**

The affected SQL now uses `IF NOT EXISTS` for the `job_log_buffer` table and related indexes, plus the keyset pagination indexes on `job_runs`.
