### PR TITLE
feat(queues): Add pressure sorting and table tooltips

### DIFF
--- a/apps/app/src/app/_components/queue-performance-table.tsx
+++ b/apps/app/src/app/_components/queue-performance-table.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { Skeleton } from "~/components/ui/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
+import { TruncatedTooltip } from "~/components/ui/truncated-tooltip";
 
 type QueuePerformance = z.output<typeof dashboardQueuePerformanceOutput>;
 
@@ -128,8 +129,8 @@ export function QueuePerformanceTable({ queuePerformance, isLoading }: QueuePerf
                       }
                     }}
                   >
-                    <TableCell className="font-medium max-w-48 truncate" title={queue.queue}>
-                      {queue.queue}
+                    <TableCell className="max-w-48 font-medium">
+                      <TruncatedTooltip value={queue.queue} />
                     </TableCell>
                     <TableCell className="text-right font-mono">{queue.totalRuns.toLocaleString()}</TableCell>
                     <TableCell className="text-right font-mono text-green-600">

--- a/apps/app/src/app/api/queues/table/route.ts
+++ b/apps/app/src/app/api/queues/table/route.ts
@@ -1,10 +1,32 @@
 import { listQueues } from "@better-bull-board/core/queues";
-import { jobRunsTable, queuesTable } from "@better-bull-board/db";
+import { jobRunsTable, jobSchedulersTable, queuesTable } from "@better-bull-board/db";
 import { db } from "@better-bull-board/db/server";
 import { addDays, addHours, startOfDay, startOfHour } from "date-fns";
-import { and, gte, inArray, lt, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, ilike, inArray, isNotNull, lt, or, sql } from "drizzle-orm";
 import { createAuthenticatedApiRoute } from "~/lib/utils/server";
 import { getQueuesTableApiRoute } from "./schemas";
+
+type QueueCursor = {
+  waitingJobs: number;
+  activeJobs?: number;
+  pressure?: number;
+  name: string;
+};
+
+type SortDirection = "asc" | "desc";
+type CursorDirection = "next" | "prev";
+
+const pressureAverageExpression = sql<
+  number | null
+>`ROUND(AVG(EXTRACT(EPOCH FROM (${jobRunsTable.startedAt} - ${jobRunsTable.enqueuedAt})) * 1000))`;
+const pressureFilters = (dateFrom: Date, dateTo: Date) =>
+  and(
+    inArray(jobRunsTable.status, ["completed", "failed"]),
+    isNotNull(jobRunsTable.enqueuedAt),
+    isNotNull(jobRunsTable.startedAt),
+    gte(jobRunsTable.createdAt, dateFrom),
+    lt(jobRunsTable.createdAt, dateTo),
+  );
 
 function fillChartData(
   dateFrom: Date,
@@ -39,6 +61,171 @@ function fillChartData(
   return filled;
 }
 
+const waitingJobCounts = db
+  .select({
+    queue: jobRunsTable.queue,
+    waitingJobs: sql<number>`COUNT(*)::int`.as("waiting_jobs"),
+  })
+  .from(jobRunsTable)
+  .where(eq(jobRunsTable.status, "waiting"))
+  .groupBy(jobRunsTable.queue)
+  .as("waiting_job_counts");
+
+const activeJobCounts = db
+  .select({
+    queue: jobRunsTable.queue,
+    activeJobs: sql<number>`COUNT(*)::int`.as("active_jobs"),
+  })
+  .from(jobRunsTable)
+  .where(eq(jobRunsTable.status, "active"))
+  .groupBy(jobRunsTable.queue)
+  .as("active_job_counts");
+
+const getPressureStats = (dateFrom: Date, dateTo: Date) =>
+  db
+    .select({
+      queue: jobRunsTable.queue,
+      pressure: pressureAverageExpression.as("pressure"),
+    })
+    .from(jobRunsTable)
+    .where(pressureFilters(dateFrom, dateTo))
+    .groupBy(jobRunsTable.queue)
+    .as("pressure_stats");
+
+const waitingJobsExpression = sql<number>`COALESCE(${waitingJobCounts.waitingJobs}, 0)`;
+const activeJobsExpression = sql<number>`COALESCE(${activeJobCounts.activeJobs}, 0)`;
+
+const getPressureExpression = (dateFrom: Date, dateTo: Date) => {
+  const pressureStats = getPressureStats(dateFrom, dateTo);
+  return {
+    expression: sql<number>`COALESCE(${pressureStats.pressure}, 0)`,
+    table: pressureStats,
+  };
+};
+
+const getPressureCursorComparison = (
+  cursor: QueueCursor,
+  cursorDirection: CursorDirection,
+  sortDirection: SortDirection,
+  pressureExpression: ReturnType<typeof getPressureExpression>["expression"],
+) => {
+  const cursorValue = cursor.pressure ?? 0;
+  const nameComparison =
+    cursorDirection === "next" ? gt(queuesTable.name, cursor.name) : lt(queuesTable.name, cursor.name);
+  const tiedSortComparison = and(eq(pressureExpression, cursorValue), nameComparison);
+  const shouldUseGreaterThan = cursorDirection === "next" ? sortDirection === "asc" : sortDirection === "desc";
+
+  if (shouldUseGreaterThan) {
+    return or(gt(pressureExpression, cursorValue), tiedSortComparison);
+  }
+
+  return or(lt(pressureExpression, cursorValue), tiedSortComparison);
+};
+
+const getPressureSortOrder = (
+  cursorDirection: CursorDirection,
+  sortDirection: SortDirection,
+  pressureExpression: ReturnType<typeof getPressureExpression>["expression"],
+) => {
+  const orderDirection = cursorDirection === "next" ? sortDirection : sortDirection === "desc" ? "asc" : "desc";
+  const sortOrder = orderDirection === "asc" ? asc(pressureExpression) : desc(pressureExpression);
+  const nameOrder = cursorDirection === "next" ? asc(queuesTable.name) : desc(queuesTable.name);
+
+  return [sortOrder, nameOrder];
+};
+
+const listQueuesByPressure = async ({
+  cursor,
+  cursorDirection,
+  dateFrom,
+  dateTo,
+  limit,
+  search,
+  sortDirection,
+}: {
+  cursor: QueueCursor | null | undefined;
+  cursorDirection: CursorDirection;
+  dateFrom: Date;
+  dateTo: Date;
+  limit: number;
+  search: string | undefined;
+  sortDirection: SortDirection;
+}) => {
+  const pressure = getPressureExpression(dateFrom, dateTo);
+  const rows = await db
+    .select({
+      id: queuesTable.id,
+      name: queuesTable.name,
+      isPaused: queuesTable.isPaused,
+      waitingJobs: waitingJobsExpression.as("waiting_jobs"),
+      activeJobs: activeJobsExpression.as("active_jobs"),
+      pressure: pressure.expression.as("pressure"),
+      patterns: sql<string[] | null | undefined>`array_agg(${jobSchedulersTable.pattern})`.as("patterns"),
+      everys: sql<number[] | null | undefined>`array_agg(${jobSchedulersTable.every})`.as("everys"),
+    })
+    .from(queuesTable)
+    .leftJoin(waitingJobCounts, eq(waitingJobCounts.queue, queuesTable.name))
+    .leftJoin(activeJobCounts, eq(activeJobCounts.queue, queuesTable.name))
+    .leftJoin(pressure.table, eq(pressure.table.queue, queuesTable.name))
+    .leftJoin(jobSchedulersTable, eq(jobSchedulersTable.queueId, queuesTable.id))
+    .where(
+      and(
+        cursor ? getPressureCursorComparison(cursor, cursorDirection, sortDirection, pressure.expression) : undefined,
+        search ? ilike(queuesTable.name, `%${search}%`) : undefined,
+      ),
+    )
+    .groupBy(queuesTable.id, waitingJobCounts.waitingJobs, activeJobCounts.activeJobs, pressure.table.pressure)
+    .orderBy(...getPressureSortOrder(cursorDirection, sortDirection, pressure.expression))
+    .limit(limit + 1);
+
+  const hasExtra = rows.length > limit;
+
+  if (hasExtra) {
+    rows.pop();
+  }
+
+  const queueRows = cursorDirection === "prev" ? rows.reverse() : rows;
+  const [total] = await db
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(queuesTable)
+    .where(search ? ilike(queuesTable.name, `%${search}%`) : undefined);
+  const firstRow = queueRows[0];
+  const lastRow = queueRows.at(-1);
+  const hasNewerPage = cursorDirection === "next" ? Boolean(cursor) : hasExtra;
+  const hasOlderPage = cursorDirection === "prev" ? Boolean(cursor) : hasExtra;
+
+  return {
+    queues: queueRows.map((row) => ({
+      name: row.name,
+      isPaused: row.isPaused,
+      patterns: row.patterns?.filter(Boolean) ?? [],
+      everys: row.everys?.filter(Boolean) ?? [],
+      waitingJobs: Number(row.waitingJobs ?? 0),
+      activeJobs: Number(row.activeJobs ?? 0),
+      pressure: Number(row.pressure ?? 0),
+    })),
+    nextCursor:
+      hasOlderPage && lastRow
+        ? {
+            name: lastRow.name,
+            waitingJobs: Number(lastRow.waitingJobs ?? 0),
+            activeJobs: Number(lastRow.activeJobs ?? 0),
+            pressure: Number(lastRow.pressure ?? 0),
+          }
+        : null,
+    prevCursor:
+      hasNewerPage && firstRow
+        ? {
+            name: firstRow.name,
+            waitingJobs: Number(firstRow.waitingJobs ?? 0),
+            activeJobs: Number(firstRow.activeJobs ?? 0),
+            pressure: Number(firstRow.pressure ?? 0),
+          }
+        : null,
+    total: Number(total?.count ?? 0),
+  };
+};
+
 export const POST = createAuthenticatedApiRoute({
   apiRoute: getQueuesTableApiRoute,
   async handler(input) {
@@ -46,21 +233,31 @@ export const POST = createAuthenticatedApiRoute({
     const cursorDirection = input.cursorDirection ?? "next";
     const cursor = input.cursor;
     const limit = input.limit ?? 20;
-
-    const queuePage = await listQueues({
-      search,
-      cursor,
-      cursorDirection,
-      sortBy,
-      sortDirection,
-      limit,
-    });
-    const queueRows = queuePage.queues;
-
-    const queueNames = queueRows.map((row) => row.name);
     const timePeriodDays = Number(timePeriod);
     const dateFrom = new Date(Date.now() - timePeriodDays * 24 * 60 * 60 * 1000);
     const dateTo = new Date();
+
+    const queuePage =
+      sortBy === "pressure"
+        ? await listQueuesByPressure({
+            cursor,
+            cursorDirection,
+            dateFrom,
+            dateTo,
+            limit,
+            search,
+            sortDirection,
+          })
+        : await listQueues({
+            search,
+            cursor,
+            cursorDirection,
+            sortBy,
+            sortDirection,
+            limit,
+          });
+    const queueRows = queuePage.queues;
+    const queueNames = queueRows.map((row) => row.name);
 
     const interval = timePeriodDays <= 7 ? "hour" : "day";
 
@@ -70,30 +267,18 @@ export const POST = createAuthenticatedApiRoute({
     // Single optimized query to get all queue counts at once
     const countsStart = Date.now();
     const allCounts =
-      queueNames.length > 0
-        ? await db
-            .select({
-              name: queuesTable.name,
-              // Pressure is the average time (in ms) spent in waiting state for jobs completed or failed in the time period
-              pressure: sql<number | null>`(
-          SELECT ROUND(AVG(EXTRACT(EPOCH FROM (jra."started_at" - jra."enqueued_at")) * 1000)) as pressure
-          FROM (
-            SELECT *
-            FROM ${jobRunsTable} jra
-            WHERE jra.queue = queues.name
-            AND (jra.status = 'completed' OR jra.status = 'failed')
-            AND jra.enqueued_at IS NOT NULL
-            AND jra.started_at IS NOT NULL
-            AND jra.created_at >= ${dateFrom}
-            AND jra.created_at < ${dateTo}
-            ORDER BY jra.created_at DESC
-            LIMIT 100
-          ) jra
-        )`.as("pressure"),
-            })
-            .from(queuesTable)
-            .where(inArray(queuesTable.name, queueNames))
-        : [];
+      sortBy === "pressure"
+        ? queueRows.map((row) => ({ name: row.name, pressure: "pressure" in row ? row.pressure : 0 }))
+        : queueNames.length > 0
+          ? await db
+              .select({
+                name: jobRunsTable.queue,
+                pressure: pressureAverageExpression.as("pressure"),
+              })
+              .from(jobRunsTable)
+              .where(and(inArray(jobRunsTable.queue, queueNames), pressureFilters(dateFrom, dateTo)))
+              .groupBy(jobRunsTable.queue)
+          : [];
 
     const countsTime = Date.now() - countsStart;
 
@@ -163,6 +348,13 @@ export const POST = createAuthenticatedApiRoute({
     }
 
     const statsMap = new Map(queueStats.map((stat) => [stat.queueName, stat]));
+    const getCursorWithPressure = (cursor: typeof queuePage.nextCursor) =>
+      cursor
+        ? {
+            ...cursor,
+            pressure: statsMap.get(cursor.name)?.pressure ?? 0,
+          }
+        : null;
 
     return {
       queues: queueRows.map((row) => {
@@ -183,8 +375,8 @@ export const POST = createAuthenticatedApiRoute({
           chartData: stats.chartData,
         };
       }),
-      nextCursor: queuePage.nextCursor,
-      prevCursor: queuePage.prevCursor,
+      nextCursor: getCursorWithPressure(queuePage.nextCursor),
+      prevCursor: getCursorWithPressure(queuePage.prevCursor),
       total: queuePage.total,
     };
   },

--- a/apps/app/src/app/api/queues/table/schemas.ts
+++ b/apps/app/src/app/api/queues/table/schemas.ts
@@ -3,6 +3,15 @@ import z from "zod";
 import { registerApiRoute } from "~/lib/utils/client";
 
 const getQueuesTableInput = listQueuesInputSchema.extend({
+  cursor: z
+    .object({
+      waitingJobs: z.number(),
+      activeJobs: z.number().optional(),
+      pressure: z.number().optional(),
+      name: z.string(),
+    })
+    .nullish(),
+  sortBy: z.enum(["waitingJobs", "activeJobs", "pressure"]).optional().default("waitingJobs"),
   timePeriod: z.enum(["1", "3", "7", "30"]).optional().default("1"),
 });
 
@@ -19,6 +28,22 @@ const getQueuesTableOutput = listQueuesOutputSchema.extend({
       ),
     }),
   ),
+  nextCursor: z
+    .object({
+      waitingJobs: z.number(),
+      activeJobs: z.number(),
+      pressure: z.number(),
+      name: z.string(),
+    })
+    .nullable(),
+  prevCursor: z
+    .object({
+      waitingJobs: z.number(),
+      activeJobs: z.number(),
+      pressure: z.number(),
+      name: z.string(),
+    })
+    .nullable(),
 });
 
 export const getQueuesTableApiRoute = registerApiRoute({

--- a/apps/app/src/app/queues/_components/queues-table.tsx
+++ b/apps/app/src/app/queues/_components/queues-table.tsx
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { formatDuration } from "date-fns";
 import { AnimatePresence, motion } from "framer-motion";
-import { ArrowDown, ArrowUp, ArrowUpDown, ChevronLeft, ChevronRight, Search } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, ChevronLeft, ChevronRight, Info, Search } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { createParser, parseAsString, useQueryStates } from "nuqs";
 import { getQueuesTableApiRoute } from "~/app/api/queues/table/schemas";
@@ -12,6 +12,7 @@ import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Skeleton } from "~/components/ui/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/tooltip";
 import { apiFetch, cn, smartFormatDuration } from "~/lib/utils/client";
 import { QueueActions } from "./queue-actions";
 import { QueueMiniChart } from "./queue-mini-chart";
@@ -20,6 +21,9 @@ import { type TimePeriod, TimePeriodSelector } from "./time-period-selector";
 type QueueCursor = { waitingJobs: number; activeJobs?: number; name: string };
 type SortBy = "waitingJobs" | "activeJobs";
 type SortDirection = "asc" | "desc";
+
+const PRESSURE_DESCRIPTION =
+  "Average time jobs spend waiting before starting, based on the latest completed or failed jobs in the selected time period.";
 
 const sortableQueueColumns: { key: SortBy; label: string }[] = [
   { key: "waitingJobs", label: "Waiting Jobs" },
@@ -174,7 +178,23 @@ export function QueuesTable() {
                   </button>
                 </TableHead>
               ))}
-              <TableHead style={{ width: "240px" }}>Pressure</TableHead>
+              <TableHead style={{ width: "240px" }}>
+                <div className="flex items-center gap-1">
+                  Pressure
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        className="rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                        aria-label="What pressure means"
+                      >
+                        <Info className="size-3.5" />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-64 text-left">{PRESSURE_DESCRIPTION}</TooltipContent>
+                  </Tooltip>
+                </div>
+              </TableHead>
               <TableHead style={{ width: "70px" }}>Trend</TableHead>
               <TableHead style={{ width: "90px" }}></TableHead>
             </TableRow>

--- a/apps/app/src/app/queues/_components/queues-table.tsx
+++ b/apps/app/src/app/queues/_components/queues-table.tsx
@@ -18,12 +18,12 @@ import { QueueActions } from "./queue-actions";
 import { QueueMiniChart } from "./queue-mini-chart";
 import { type TimePeriod, TimePeriodSelector } from "./time-period-selector";
 
-type QueueCursor = { waitingJobs: number; activeJobs?: number; name: string };
-type SortBy = "waitingJobs" | "activeJobs";
+type QueueCursor = { waitingJobs: number; activeJobs?: number; pressure?: number; name: string };
+type SortBy = "waitingJobs" | "activeJobs" | "pressure";
 type SortDirection = "asc" | "desc";
 
 const PRESSURE_DESCRIPTION =
-  "Average time jobs spend waiting before starting, based on the latest completed or failed jobs in the selected time period.";
+  "Average time completed or failed jobs spend waiting before starting in the selected time period.";
 
 const sortableQueueColumns: { key: SortBy; label: string }[] = [
   { key: "waitingJobs", label: "Waiting Jobs" },
@@ -53,7 +53,8 @@ export function QueuesTable() {
   });
 
   const cursorDirection: "next" | "prev" = urlState.cursorDirection === "prev" ? "prev" : "next";
-  const sortBy: SortBy = urlState.sortBy === "activeJobs" ? "activeJobs" : "waitingJobs";
+  const sortBy: SortBy =
+    urlState.sortBy === "activeJobs" || urlState.sortBy === "pressure" ? urlState.sortBy : "waitingJobs";
   const sortDirection: SortDirection = urlState.sortDirection === "asc" ? "asc" : "desc";
   const options = {
     cursor: urlState.cursor,
@@ -179,8 +180,15 @@ export function QueuesTable() {
                 </TableHead>
               ))}
               <TableHead style={{ width: "240px" }}>
-                <div className="flex items-center gap-1">
-                  Pressure
+                <div className="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    className="flex items-center gap-1 font-medium"
+                    onClick={() => handleSort("pressure")}
+                  >
+                    Pressure
+                    {getSortIcon("pressure")}
+                  </button>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <button

--- a/apps/app/src/app/runs/_components/runs-table.tsx
+++ b/apps/app/src/app/runs/_components/runs-table.tsx
@@ -12,6 +12,7 @@ import { Badge } from "~/components/ui/badge";
 import { Checkbox } from "~/components/ui/checkbox";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/components/ui/tooltip";
+import { TruncatedTooltip } from "~/components/ui/truncated-tooltip";
 import useDebounce from "~/hooks/use-debounce";
 import { apiFetch, cn } from "~/lib/utils/client";
 import { BulkActions } from "./bulk-actions";
@@ -276,8 +277,8 @@ export function RunsTable() {
                   />
                 </div>
               </TableHead>
-              <TableHead style={{ width: "260px" }}>Job ID</TableHead>
-              <TableHead style={{ width: "120px" }}>Queue</TableHead>
+              <TableHead style={{ width: "120px" }}>Job ID</TableHead>
+              <TableHead style={{ width: "260px" }}>Queue</TableHead>
               <TableHead style={{ width: "180px" }}>Tags</TableHead>
               <TableHead style={{ width: "120px" }}>Status</TableHead>
               <TableHead style={{ width: "120px" }}>
@@ -324,10 +325,11 @@ export function RunsTable() {
                       </div>
                     </TableCell>
                     <TableCell className="font-mono text-xs">
-                      {run.jobId.slice(0, 32)}
-                      {run.jobId.length > 32 && "..."}
+                      <TruncatedTooltip value={run.jobId} />
                     </TableCell>
-                    <TableCell className="truncate">{run.queue}</TableCell>
+                    <TableCell>
+                      <TruncatedTooltip value={run.queue} />
+                    </TableCell>
                     <TableCell className="overflow-hidden">
                       {run.tags?.map((tag) => (
                         <Badge key={tag} variant="outline">
@@ -347,11 +349,7 @@ export function RunsTable() {
                       <RunTimestamp value={run.createdAt} />
                     </TableCell>
                     <TableCell className="truncate">
-                      {run.finishedAt ? (
-                        <RunTimestamp value={run.finishedAt} />
-                      ) : (
-                        "-"
-                      )}
+                      {run.finishedAt ? <RunTimestamp value={run.finishedAt} /> : "-"}
                     </TableCell>
                     <TableCell className="max-w-48">
                       {run.status === "failed" && run.errorMessage ? (

--- a/apps/app/src/components/ui/truncated-tooltip.tsx
+++ b/apps/app/src/components/ui/truncated-tooltip.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { cn } from "~/lib/utils/client";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
+
+type TruncatedTooltipProps = {
+  value: string;
+  className?: string;
+};
+
+export function TruncatedTooltip({ value, className }: TruncatedTooltipProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={cn("inline-block max-w-full truncate align-bottom", className)}>{value}</span>
+      </TooltipTrigger>
+      <TooltipContent
+        side="top"
+        sideOffset={6}
+        className="max-w-[min(32rem,calc(100vw-2rem))] whitespace-normal break-all text-left"
+      >
+        {value}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/app/src/components/ui/truncated-tooltip.tsx
+++ b/apps/app/src/components/ui/truncated-tooltip.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { cn } from "~/lib/utils/client";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
 


### PR DESCRIPTION
Make table values and metrics easier to understand without leaving the list views.

The runs table now gives Queue more column width by shrinking Job ID and shows full job and queue identifiers through a shared tooltip. The queues table explains the Pressure metric inline so users can tell it represents average time jobs spend waiting before starting.

**Shared Truncated Tooltip**

The shared component anchors tooltips to the visible truncated text and keeps long identifiers constrained within the viewport. The queue performance table uses the same component instead of a native browser title.

**Pressure Metric**

Pressure now uses average wait time for completed or failed jobs in the selected time period. That removes the previous latest-100 sample and gives the API one consistent value for display and sorting.

**Pressure Sorting**

The Pressure column is now sortable with keyset pagination, including queue-name tie-breaking so page navigation stays stable.