### PR TITLE
fix(queues): Keep pressure display unsorted

### DIFF
--- a/apps/app/src/app/api/queues/table/route.ts
+++ b/apps/app/src/app/api/queues/table/route.ts
@@ -1,20 +1,10 @@
 import { listQueues } from "@better-bull-board/core/queues";
-import { jobRunsTable, jobSchedulersTable, queuesTable } from "@better-bull-board/db";
+import { jobRunsTable } from "@better-bull-board/db";
 import { db } from "@better-bull-board/db/server";
 import { addDays, addHours, startOfDay, startOfHour } from "date-fns";
-import { and, asc, desc, eq, gt, gte, ilike, inArray, isNotNull, lt, or, sql } from "drizzle-orm";
+import { and, gte, inArray, isNotNull, lt, sql } from "drizzle-orm";
 import { createAuthenticatedApiRoute } from "~/lib/utils/server";
 import { getQueuesTableApiRoute } from "./schemas";
-
-type QueueCursor = {
-  waitingJobs: number;
-  activeJobs?: number;
-  pressure?: number;
-  name: string;
-};
-
-type SortDirection = "asc" | "desc";
-type CursorDirection = "next" | "prev";
 
 const pressureAverageExpression = sql<
   number | null
@@ -61,171 +51,6 @@ function fillChartData(
   return filled;
 }
 
-const waitingJobCounts = db
-  .select({
-    queue: jobRunsTable.queue,
-    waitingJobs: sql<number>`COUNT(*)::int`.as("waiting_jobs"),
-  })
-  .from(jobRunsTable)
-  .where(eq(jobRunsTable.status, "waiting"))
-  .groupBy(jobRunsTable.queue)
-  .as("waiting_job_counts");
-
-const activeJobCounts = db
-  .select({
-    queue: jobRunsTable.queue,
-    activeJobs: sql<number>`COUNT(*)::int`.as("active_jobs"),
-  })
-  .from(jobRunsTable)
-  .where(eq(jobRunsTable.status, "active"))
-  .groupBy(jobRunsTable.queue)
-  .as("active_job_counts");
-
-const getPressureStats = (dateFrom: Date, dateTo: Date) =>
-  db
-    .select({
-      queue: jobRunsTable.queue,
-      pressure: pressureAverageExpression.as("pressure"),
-    })
-    .from(jobRunsTable)
-    .where(pressureFilters(dateFrom, dateTo))
-    .groupBy(jobRunsTable.queue)
-    .as("pressure_stats");
-
-const waitingJobsExpression = sql<number>`COALESCE(${waitingJobCounts.waitingJobs}, 0)`;
-const activeJobsExpression = sql<number>`COALESCE(${activeJobCounts.activeJobs}, 0)`;
-
-const getPressureExpression = (dateFrom: Date, dateTo: Date) => {
-  const pressureStats = getPressureStats(dateFrom, dateTo);
-  return {
-    expression: sql<number>`COALESCE(${pressureStats.pressure}, 0)`,
-    table: pressureStats,
-  };
-};
-
-const getPressureCursorComparison = (
-  cursor: QueueCursor,
-  cursorDirection: CursorDirection,
-  sortDirection: SortDirection,
-  pressureExpression: ReturnType<typeof getPressureExpression>["expression"],
-) => {
-  const cursorValue = cursor.pressure ?? 0;
-  const nameComparison =
-    cursorDirection === "next" ? gt(queuesTable.name, cursor.name) : lt(queuesTable.name, cursor.name);
-  const tiedSortComparison = and(eq(pressureExpression, cursorValue), nameComparison);
-  const shouldUseGreaterThan = cursorDirection === "next" ? sortDirection === "asc" : sortDirection === "desc";
-
-  if (shouldUseGreaterThan) {
-    return or(gt(pressureExpression, cursorValue), tiedSortComparison);
-  }
-
-  return or(lt(pressureExpression, cursorValue), tiedSortComparison);
-};
-
-const getPressureSortOrder = (
-  cursorDirection: CursorDirection,
-  sortDirection: SortDirection,
-  pressureExpression: ReturnType<typeof getPressureExpression>["expression"],
-) => {
-  const orderDirection = cursorDirection === "next" ? sortDirection : sortDirection === "desc" ? "asc" : "desc";
-  const sortOrder = orderDirection === "asc" ? asc(pressureExpression) : desc(pressureExpression);
-  const nameOrder = cursorDirection === "next" ? asc(queuesTable.name) : desc(queuesTable.name);
-
-  return [sortOrder, nameOrder];
-};
-
-const listQueuesByPressure = async ({
-  cursor,
-  cursorDirection,
-  dateFrom,
-  dateTo,
-  limit,
-  search,
-  sortDirection,
-}: {
-  cursor: QueueCursor | null | undefined;
-  cursorDirection: CursorDirection;
-  dateFrom: Date;
-  dateTo: Date;
-  limit: number;
-  search: string | undefined;
-  sortDirection: SortDirection;
-}) => {
-  const pressure = getPressureExpression(dateFrom, dateTo);
-  const rows = await db
-    .select({
-      id: queuesTable.id,
-      name: queuesTable.name,
-      isPaused: queuesTable.isPaused,
-      waitingJobs: waitingJobsExpression.as("waiting_jobs"),
-      activeJobs: activeJobsExpression.as("active_jobs"),
-      pressure: pressure.expression.as("pressure"),
-      patterns: sql<string[] | null | undefined>`array_agg(${jobSchedulersTable.pattern})`.as("patterns"),
-      everys: sql<number[] | null | undefined>`array_agg(${jobSchedulersTable.every})`.as("everys"),
-    })
-    .from(queuesTable)
-    .leftJoin(waitingJobCounts, eq(waitingJobCounts.queue, queuesTable.name))
-    .leftJoin(activeJobCounts, eq(activeJobCounts.queue, queuesTable.name))
-    .leftJoin(pressure.table, eq(pressure.table.queue, queuesTable.name))
-    .leftJoin(jobSchedulersTable, eq(jobSchedulersTable.queueId, queuesTable.id))
-    .where(
-      and(
-        cursor ? getPressureCursorComparison(cursor, cursorDirection, sortDirection, pressure.expression) : undefined,
-        search ? ilike(queuesTable.name, `%${search}%`) : undefined,
-      ),
-    )
-    .groupBy(queuesTable.id, waitingJobCounts.waitingJobs, activeJobCounts.activeJobs, pressure.table.pressure)
-    .orderBy(...getPressureSortOrder(cursorDirection, sortDirection, pressure.expression))
-    .limit(limit + 1);
-
-  const hasExtra = rows.length > limit;
-
-  if (hasExtra) {
-    rows.pop();
-  }
-
-  const queueRows = cursorDirection === "prev" ? rows.reverse() : rows;
-  const [total] = await db
-    .select({ count: sql<number>`COUNT(*)` })
-    .from(queuesTable)
-    .where(search ? ilike(queuesTable.name, `%${search}%`) : undefined);
-  const firstRow = queueRows[0];
-  const lastRow = queueRows.at(-1);
-  const hasNewerPage = cursorDirection === "next" ? Boolean(cursor) : hasExtra;
-  const hasOlderPage = cursorDirection === "prev" ? Boolean(cursor) : hasExtra;
-
-  return {
-    queues: queueRows.map((row) => ({
-      name: row.name,
-      isPaused: row.isPaused,
-      patterns: row.patterns?.filter(Boolean) ?? [],
-      everys: row.everys?.filter(Boolean) ?? [],
-      waitingJobs: Number(row.waitingJobs ?? 0),
-      activeJobs: Number(row.activeJobs ?? 0),
-      pressure: Number(row.pressure ?? 0),
-    })),
-    nextCursor:
-      hasOlderPage && lastRow
-        ? {
-            name: lastRow.name,
-            waitingJobs: Number(lastRow.waitingJobs ?? 0),
-            activeJobs: Number(lastRow.activeJobs ?? 0),
-            pressure: Number(lastRow.pressure ?? 0),
-          }
-        : null,
-    prevCursor:
-      hasNewerPage && firstRow
-        ? {
-            name: firstRow.name,
-            waitingJobs: Number(firstRow.waitingJobs ?? 0),
-            activeJobs: Number(firstRow.activeJobs ?? 0),
-            pressure: Number(firstRow.pressure ?? 0),
-          }
-        : null,
-    total: Number(total?.count ?? 0),
-  };
-};
-
 export const POST = createAuthenticatedApiRoute({
   apiRoute: getQueuesTableApiRoute,
   async handler(input) {
@@ -237,25 +62,14 @@ export const POST = createAuthenticatedApiRoute({
     const dateFrom = new Date(Date.now() - timePeriodDays * 24 * 60 * 60 * 1000);
     const dateTo = new Date();
 
-    const queuePage =
-      sortBy === "pressure"
-        ? await listQueuesByPressure({
-            cursor,
-            cursorDirection,
-            dateFrom,
-            dateTo,
-            limit,
-            search,
-            sortDirection,
-          })
-        : await listQueues({
-            search,
-            cursor,
-            cursorDirection,
-            sortBy,
-            sortDirection,
-            limit,
-          });
+    const queuePage = await listQueues({
+      search,
+      cursor,
+      cursorDirection,
+      sortBy,
+      sortDirection,
+      limit,
+    });
     const queueRows = queuePage.queues;
     const queueNames = queueRows.map((row) => row.name);
 
@@ -267,18 +81,16 @@ export const POST = createAuthenticatedApiRoute({
     // Single optimized query to get all queue counts at once
     const countsStart = Date.now();
     const allCounts =
-      sortBy === "pressure"
-        ? queueRows.map((row) => ({ name: row.name, pressure: "pressure" in row ? row.pressure : 0 }))
-        : queueNames.length > 0
-          ? await db
-              .select({
-                name: jobRunsTable.queue,
-                pressure: pressureAverageExpression.as("pressure"),
-              })
-              .from(jobRunsTable)
-              .where(and(inArray(jobRunsTable.queue, queueNames), pressureFilters(dateFrom, dateTo)))
-              .groupBy(jobRunsTable.queue)
-          : [];
+      queueNames.length > 0
+        ? await db
+            .select({
+              name: jobRunsTable.queue,
+              pressure: pressureAverageExpression.as("pressure"),
+            })
+            .from(jobRunsTable)
+            .where(and(inArray(jobRunsTable.queue, queueNames), pressureFilters(dateFrom, dateTo)))
+            .groupBy(jobRunsTable.queue)
+        : [];
 
     const countsTime = Date.now() - countsStart;
 
@@ -348,13 +160,6 @@ export const POST = createAuthenticatedApiRoute({
     }
 
     const statsMap = new Map(queueStats.map((stat) => [stat.queueName, stat]));
-    const getCursorWithPressure = (cursor: typeof queuePage.nextCursor) =>
-      cursor
-        ? {
-            ...cursor,
-            pressure: statsMap.get(cursor.name)?.pressure ?? 0,
-          }
-        : null;
 
     return {
       queues: queueRows.map((row) => {
@@ -375,8 +180,8 @@ export const POST = createAuthenticatedApiRoute({
           chartData: stats.chartData,
         };
       }),
-      nextCursor: getCursorWithPressure(queuePage.nextCursor),
-      prevCursor: getCursorWithPressure(queuePage.prevCursor),
+      nextCursor: queuePage.nextCursor,
+      prevCursor: queuePage.prevCursor,
       total: queuePage.total,
     };
   },

--- a/apps/app/src/app/api/queues/table/schemas.ts
+++ b/apps/app/src/app/api/queues/table/schemas.ts
@@ -3,15 +3,6 @@ import z from "zod";
 import { registerApiRoute } from "~/lib/utils/client";
 
 const getQueuesTableInput = listQueuesInputSchema.extend({
-  cursor: z
-    .object({
-      waitingJobs: z.number(),
-      activeJobs: z.number().optional(),
-      pressure: z.number().optional(),
-      name: z.string(),
-    })
-    .nullish(),
-  sortBy: z.enum(["waitingJobs", "activeJobs", "pressure"]).optional().default("waitingJobs"),
   timePeriod: z.enum(["1", "3", "7", "30"]).optional().default("1"),
 });
 
@@ -28,22 +19,6 @@ const getQueuesTableOutput = listQueuesOutputSchema.extend({
       ),
     }),
   ),
-  nextCursor: z
-    .object({
-      waitingJobs: z.number(),
-      activeJobs: z.number(),
-      pressure: z.number(),
-      name: z.string(),
-    })
-    .nullable(),
-  prevCursor: z
-    .object({
-      waitingJobs: z.number(),
-      activeJobs: z.number(),
-      pressure: z.number(),
-      name: z.string(),
-    })
-    .nullable(),
 });
 
 export const getQueuesTableApiRoute = registerApiRoute({

--- a/apps/app/src/app/queues/_components/queues-table.tsx
+++ b/apps/app/src/app/queues/_components/queues-table.tsx
@@ -18,8 +18,8 @@ import { QueueActions } from "./queue-actions";
 import { QueueMiniChart } from "./queue-mini-chart";
 import { type TimePeriod, TimePeriodSelector } from "./time-period-selector";
 
-type QueueCursor = { waitingJobs: number; activeJobs?: number; pressure?: number; name: string };
-type SortBy = "waitingJobs" | "activeJobs" | "pressure";
+type QueueCursor = { waitingJobs: number; activeJobs?: number; name: string };
+type SortBy = "waitingJobs" | "activeJobs";
 type SortDirection = "asc" | "desc";
 
 const PRESSURE_DESCRIPTION =
@@ -53,8 +53,7 @@ export function QueuesTable() {
   });
 
   const cursorDirection: "next" | "prev" = urlState.cursorDirection === "prev" ? "prev" : "next";
-  const sortBy: SortBy =
-    urlState.sortBy === "activeJobs" || urlState.sortBy === "pressure" ? urlState.sortBy : "waitingJobs";
+  const sortBy: SortBy = urlState.sortBy === "activeJobs" ? "activeJobs" : "waitingJobs";
   const sortDirection: SortDirection = urlState.sortDirection === "asc" ? "asc" : "desc";
   const options = {
     cursor: urlState.cursor,
@@ -181,14 +180,7 @@ export function QueuesTable() {
               ))}
               <TableHead style={{ width: "240px" }}>
                 <div className="flex items-center gap-1.5">
-                  <button
-                    type="button"
-                    className="flex items-center gap-1 font-medium"
-                    onClick={() => handleSort("pressure")}
-                  >
-                    Pressure
-                    {getSortIcon("pressure")}
-                  </button>
+                  <span>Pressure</span>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <button


### PR DESCRIPTION
Remove Pressure as a sortable queues-table column while keeping the metric visible with its explanatory tooltip.

The previous pressure sort path had to aggregate all completed and failed jobs in the selected time window before pagination. Keeping Pressure as a display-only metric avoids shipping that expensive sort behavior while preserving the useful context for visible queues.

**Pressure Display**

The queues table still shows average wait time for completed or failed jobs in the selected period, but only for the currently visible queues.

**Queue Sorting**

The API and UI return to the existing Waiting Jobs and Active Jobs sort options. Pressure sorting can come back later from a rollup or other bounded metric source.