### PR TITLE
feat(queues): Add pressure sorting

### DIFF
--- a/apps/app/src/app/api/queues/table/route.ts
+++ b/apps/app/src/app/api/queues/table/route.ts
@@ -1,30 +1,16 @@
 import { listQueues } from "@better-bull-board/core/queues";
-import { jobRunsTable } from "@better-bull-board/db";
+import { dashboardQueueHourlyStatsTable, jobRunsTable } from "@better-bull-board/db";
 import { db } from "@better-bull-board/db/server";
 import { addDays, addHours, startOfDay, startOfHour } from "date-fns";
-import { and, gte, inArray, isNotNull, lt, sql } from "drizzle-orm";
+import { and, gte, inArray, lt, sql } from "drizzle-orm";
 import { createAuthenticatedApiRoute } from "~/lib/utils/server";
 import { getQueuesTableApiRoute } from "./schemas";
 
-const pressureAverageExpression = sql<
-  number | null
->`ROUND(AVG(EXTRACT(EPOCH FROM (${jobRunsTable.startedAt} - ${jobRunsTable.enqueuedAt})) * 1000))`;
-const pressureFilters = (dateFrom: Date, dateTo: Date) =>
-  and(
-    inArray(jobRunsTable.status, ["completed", "failed"]),
-    isNotNull(jobRunsTable.enqueuedAt),
-    isNotNull(jobRunsTable.startedAt),
-    gte(jobRunsTable.createdAt, dateFrom),
-    lt(jobRunsTable.createdAt, dateTo),
-  );
+type ChartDataPoint = { timestamp: string; completed: number; failed: number };
+type ChartStep = "hour" | "day";
 
-function fillChartData(
-  dateFrom: Date,
-  dateTo: Date,
-  stepKind: string,
-  chartData: { timestamp: string; completed: number; failed: number }[],
-) {
-  const filled: { timestamp: string; completed: number; failed: number }[] = [];
+function fillChartData(dateFrom: Date, dateTo: Date, stepKind: ChartStep, chartData: ChartDataPoint[]) {
+  const filled: ChartDataPoint[] = [];
   const map = new Map(chartData.map((d) => [new Date(d.timestamp).toISOString().slice(0, 19).replace("T", " "), d]));
 
   for (let d = new Date(dateFrom); d <= dateTo; d = stepKind === "hour" ? addHours(d, 1) : addDays(d, 1)) {
@@ -33,12 +19,8 @@ function fillChartData(
         ? startOfHour(d).toISOString().slice(0, 19).replace("T", " ")
         : startOfDay(d).toISOString().slice(0, 19).replace("T", " ");
 
-    if (map.has(ts)) {
-      const data = map.get(ts) as {
-        timestamp: string;
-        completed: number;
-        failed: number;
-      };
+    const data = map.get(ts);
+    if (data) {
       filled.push({
         ...data,
         completed: Number(data.completed),
@@ -61,6 +43,8 @@ export const POST = createAuthenticatedApiRoute({
     const timePeriodDays = Number(timePeriod);
     const dateFrom = new Date(Date.now() - timePeriodDays * 24 * 60 * 60 * 1000);
     const dateTo = new Date();
+    const pressureDateFrom = startOfHour(dateFrom);
+    const pressureDateTo = startOfHour(dateTo);
 
     const queuePage = await listQueues({
       search,
@@ -69,6 +53,8 @@ export const POST = createAuthenticatedApiRoute({
       sortBy,
       sortDirection,
       limit,
+      pressureDateFrom,
+      pressureDateTo,
     });
     const queueRows = queuePage.queues;
     const queueNames = queueRows.map((row) => row.name);
@@ -78,21 +64,28 @@ export const POST = createAuthenticatedApiRoute({
     // Performance logging
     const performanceStart = Date.now();
 
-    // Single optimized query to get all queue counts at once
-    const countsStart = Date.now();
-    const allCounts =
+    const pressureStart = Date.now();
+    const allPressureData =
       queueNames.length > 0
         ? await db
             .select({
-              name: jobRunsTable.queue,
-              pressure: pressureAverageExpression.as("pressure"),
+              queueName: dashboardQueueHourlyStatsTable.queue,
+              pressure: sql<number | null>`ROUND(
+                SUM(${dashboardQueueHourlyStatsTable.pressureTotalMs})::numeric
+                / NULLIF(SUM(${dashboardQueueHourlyStatsTable.pressureCount}), 0)
+              )`.as("pressure"),
             })
-            .from(jobRunsTable)
-            .where(and(inArray(jobRunsTable.queue, queueNames), pressureFilters(dateFrom, dateTo)))
-            .groupBy(jobRunsTable.queue)
+            .from(dashboardQueueHourlyStatsTable)
+            .where(
+              and(
+                inArray(dashboardQueueHourlyStatsTable.queue, queueNames),
+                gte(dashboardQueueHourlyStatsTable.bucketStart, pressureDateFrom),
+                lt(dashboardQueueHourlyStatsTable.bucketStart, pressureDateTo),
+              ),
+            )
+            .groupBy(dashboardQueueHourlyStatsTable.queue)
         : [];
-
-    const countsTime = Date.now() - countsStart;
+    const pressureTime = Date.now() - pressureStart;
 
     // Single optimized query to get all chart data at once
     const chartStart = Date.now();
@@ -126,7 +119,9 @@ export const POST = createAuthenticatedApiRoute({
     const processStart = Date.now();
 
     // Create maps for efficient lookup
-    const countsMap = new Map(allCounts.map((count) => [count.name, count]));
+    const pressureMap = new Map(
+      allPressureData.map((pressure) => [pressure.queueName, Number(pressure.pressure ?? 0)]),
+    );
 
     const chartDataMap = new Map<string, { timestamp: string; completed: number; failed: number }[]>();
     for (const chart of allChartData) {
@@ -141,12 +136,11 @@ export const POST = createAuthenticatedApiRoute({
     }
 
     const queueStats = queueNames.map((queueName) => {
-      const counts = countsMap.get(queueName);
       const chartData = chartDataMap.get(queueName) ?? [];
 
       return {
         queueName,
-        pressure: Number(counts?.pressure ?? 0),
+        pressure: pressureMap.get(queueName) ?? 0,
         chartData: fillChartData(dateFrom, dateTo, interval, chartData),
       };
     });
@@ -155,7 +149,7 @@ export const POST = createAuthenticatedApiRoute({
     const totalTime = Date.now() - performanceStart;
     if (totalTime > 1000) {
       console.log(
-        `[Performance] Total queue stats calculation completed in ${totalTime}ms (Counts: ${countsTime}ms, Chart: ${chartTime}ms, Process: ${processTime}ms)`,
+        `[Performance] Total queue stats calculation completed in ${totalTime}ms (Pressure: ${pressureTime}ms, Chart: ${chartTime}ms, Process: ${processTime}ms)`,
       );
     }
 

--- a/apps/app/src/app/api/queues/table/schemas.ts
+++ b/apps/app/src/app/api/queues/table/schemas.ts
@@ -1,10 +1,21 @@
-import { listQueuesInputSchema, listQueuesOutputSchema } from "@better-bull-board/core/queue-schemas";
+import { listQueuesBaseInputSchema, listQueuesOutputSchema } from "@better-bull-board/core/queue-schemas";
 import z from "zod";
 import { registerApiRoute } from "~/lib/utils/client";
 
-const getQueuesTableInput = listQueuesInputSchema.extend({
-  timePeriod: z.enum(["1", "3", "7", "30"]).optional().default("1"),
-});
+const getQueuesTableInput = listQueuesBaseInputSchema
+  .omit({ pressureDateFrom: true, pressureDateTo: true })
+  .extend({
+    timePeriod: z.enum(["1", "3", "7", "30"]).optional().default("1"),
+  })
+  .superRefine((input, ctx) => {
+    if (input.sortBy === "pressure" && input.cursor && input.cursor.pressure === undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Pressure cursor is required when sorting by pressure",
+        path: ["cursor", "pressure"],
+      });
+    }
+  });
 
 const getQueuesTableOutput = listQueuesOutputSchema.extend({
   queues: z.array(

--- a/apps/app/src/app/queues/_components/queues-table.tsx
+++ b/apps/app/src/app/queues/_components/queues-table.tsx
@@ -18,12 +18,12 @@ import { QueueActions } from "./queue-actions";
 import { QueueMiniChart } from "./queue-mini-chart";
 import { type TimePeriod, TimePeriodSelector } from "./time-period-selector";
 
-type QueueCursor = { waitingJobs: number; activeJobs?: number; name: string };
-type SortBy = "waitingJobs" | "activeJobs";
+type QueueCursor = { waitingJobs: number; activeJobs?: number; pressure?: number; name: string };
+type SortBy = "waitingJobs" | "activeJobs" | "pressure";
 type SortDirection = "asc" | "desc";
 
 const PRESSURE_DESCRIPTION =
-  "Average time completed or failed jobs spend waiting before starting in the selected time period.";
+  "Average time completed or failed jobs spend waiting before starting, from completed hourly rollups in the selected time period.";
 
 const sortableQueueColumns: { key: SortBy; label: string }[] = [
   { key: "waitingJobs", label: "Waiting Jobs" },
@@ -53,7 +53,8 @@ export function QueuesTable() {
   });
 
   const cursorDirection: "next" | "prev" = urlState.cursorDirection === "prev" ? "prev" : "next";
-  const sortBy: SortBy = urlState.sortBy === "activeJobs" ? "activeJobs" : "waitingJobs";
+  const sortBy: SortBy =
+    urlState.sortBy === "activeJobs" ? "activeJobs" : urlState.sortBy === "pressure" ? "pressure" : "waitingJobs";
   const sortDirection: SortDirection = urlState.sortDirection === "asc" ? "asc" : "desc";
   const options = {
     cursor: urlState.cursor,
@@ -180,7 +181,14 @@ export function QueuesTable() {
               ))}
               <TableHead style={{ width: "240px" }}>
                 <div className="flex items-center gap-1.5">
-                  <span>Pressure</span>
+                  <button
+                    type="button"
+                    className="flex items-center gap-1 font-medium"
+                    onClick={() => handleSort("pressure")}
+                  >
+                    Pressure
+                    {getSortIcon("pressure")}
+                  </button>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <button

--- a/apps/ingest/src/repeats/dashboard-rollups.ts
+++ b/apps/ingest/src/repeats/dashboard-rollups.ts
@@ -39,6 +39,8 @@ export const refreshLastCompletedDashboardRollupHour = async () => {
             "duration_count",
             "duration_min_ms",
             "duration_max_ms",
+            "pressure_total_ms",
+            "pressure_count",
             "updated_at"
           )
           SELECT
@@ -62,6 +64,19 @@ export const refreshLastCompletedDashboardRollupHour = async () => {
             MAX("duration_ms") FILTER (
               WHERE "status" = 'completed'::"job_status" AND "duration_ms" IS NOT NULL
             )::integer AS "duration_max_ms",
+            COALESCE(
+              SUM(EXTRACT(EPOCH FROM ("started_at" - "enqueued_at")) * 1000) FILTER (
+                WHERE "status" IN ('completed'::"job_status", 'failed'::"job_status")
+                  AND "enqueued_at" IS NOT NULL
+                  AND "started_at" IS NOT NULL
+              ),
+              0
+            )::bigint AS "pressure_total_ms",
+            COUNT(*) FILTER (
+              WHERE "status" IN ('completed'::"job_status", 'failed'::"job_status")
+                AND "enqueued_at" IS NOT NULL
+                AND "started_at" IS NOT NULL
+            )::bigint AS "pressure_count",
             now()
           FROM "job_runs"
           WHERE "created_at" >= date_trunc('hour', now() - interval '1 hour')::timestamp
@@ -77,6 +92,8 @@ export const refreshLastCompletedDashboardRollupHour = async () => {
             "duration_count" = EXCLUDED."duration_count",
             "duration_min_ms" = EXCLUDED."duration_min_ms",
             "duration_max_ms" = EXCLUDED."duration_max_ms",
+            "pressure_total_ms" = EXCLUDED."pressure_total_ms",
+            "pressure_count" = EXCLUDED."pressure_count",
             "updated_at" = now()
         `);
 

--- a/packages/core/src/queue-schemas.ts
+++ b/packages/core/src/queue-schemas.ts
@@ -1,18 +1,57 @@
 import { z } from "zod";
 
-export const listQueuesInputSchema = z.object({
+export const listQueuesBaseInputSchema = z.object({
   cursor: z
     .object({
       waitingJobs: z.number(),
       activeJobs: z.number().optional(),
+      pressure: z.number().optional(),
       name: z.string(),
     })
     .nullish(),
   cursorDirection: z.enum(["next", "prev"]).optional(),
   search: z.string().optional(),
-  sortBy: z.enum(["waitingJobs", "activeJobs"]).optional().default("waitingJobs"),
+  sortBy: z.enum(["waitingJobs", "activeJobs", "pressure"]).optional().default("waitingJobs"),
   sortDirection: z.enum(["asc", "desc"]).optional().default("desc"),
+  pressureDateFrom: z.date().optional(),
+  pressureDateTo: z.date().optional(),
   limit: z.number().min(1).max(100).optional(),
+});
+
+export const listQueuesInputSchema = listQueuesBaseInputSchema.superRefine((input, ctx) => {
+  if (input.sortBy === "pressure") {
+    if (!input.pressureDateFrom) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Pressure date from is required when sorting by pressure",
+        path: ["pressureDateFrom"],
+      });
+    }
+
+    if (!input.pressureDateTo) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Pressure date to is required when sorting by pressure",
+        path: ["pressureDateTo"],
+      });
+    }
+
+    if (input.pressureDateFrom && input.pressureDateTo && input.pressureDateFrom >= input.pressureDateTo) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Pressure date from must be before pressure date to",
+        path: ["pressureDateFrom"],
+      });
+    }
+
+    if (input.cursor && input.cursor.pressure === undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Pressure cursor is required when sorting by pressure",
+        path: ["cursor", "pressure"],
+      });
+    }
+  }
 });
 
 export const listQueuesOutputSchema = z.object({
@@ -24,12 +63,14 @@ export const listQueuesOutputSchema = z.object({
       everys: z.array(z.number()),
       waitingJobs: z.number(),
       activeJobs: z.number(),
+      pressure: z.number(),
     }),
   ),
   nextCursor: z
     .object({
       waitingJobs: z.number(),
       activeJobs: z.number(),
+      pressure: z.number(),
       name: z.string(),
     })
     .nullable(),
@@ -37,6 +78,7 @@ export const listQueuesOutputSchema = z.object({
     .object({
       waitingJobs: z.number(),
       activeJobs: z.number(),
+      pressure: z.number(),
       name: z.string(),
     })
     .nullable(),

--- a/packages/core/src/queues.ts
+++ b/packages/core/src/queues.ts
@@ -1,13 +1,13 @@
-import { jobRunsTable, jobSchedulersTable, queuesTable } from "@better-bull-board/db";
+import { dashboardQueueHourlyStatsTable, jobRunsTable, jobSchedulersTable, queuesTable } from "@better-bull-board/db";
 import { db } from "@better-bull-board/db/server";
-import { and, asc, desc, eq, gt, ilike, lt, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, ilike, lt, or, sql } from "drizzle-orm";
 import type { z } from "zod";
 import { listQueuesInputSchema, listQueuesOutputSchema } from "./queue-schemas";
 
 type CursorDirection = "next" | "prev";
-type QueueSortBy = "waitingJobs" | "activeJobs";
+type QueueSortBy = "waitingJobs" | "activeJobs" | "pressure";
 type SortDirection = "asc" | "desc";
-type QueueCursor = { waitingJobs: number; activeJobs?: number; name: string };
+type QueueCursor = { waitingJobs: number; activeJobs?: number; pressure?: number; name: string };
 
 const waitingJobCounts = db
   .select({
@@ -33,12 +33,55 @@ const activeJobCounts = db
 
 const activeJobsExpression = sql<number>`COALESCE(${activeJobCounts.activeJobs}, 0)`;
 
-const getSortExpression = (sortBy: QueueSortBy) => {
+const queueSelectFields = {
+  id: queuesTable.id,
+  name: queuesTable.name,
+  isPaused: queuesTable.isPaused,
+  waitingJobs: waitingJobsExpression.as("waiting_jobs"),
+  activeJobs: activeJobsExpression.as("active_jobs"),
+  patterns: sql<string[] | null | undefined>`array_agg(${jobSchedulersTable.pattern})`.as("patterns"),
+  everys: sql<number[] | null | undefined>`array_agg(${jobSchedulersTable.every})`.as("everys"),
+};
+
+const buildPressureStats = (dateFrom?: Date, dateTo?: Date) =>
+  db
+    .select({
+      queue: dashboardQueueHourlyStatsTable.queue,
+      pressure: sql<number | null>`ROUND(
+        SUM(${dashboardQueueHourlyStatsTable.pressureTotalMs})::numeric
+        / NULLIF(SUM(${dashboardQueueHourlyStatsTable.pressureCount}), 0)
+      )`.as("pressure"),
+    })
+    .from(dashboardQueueHourlyStatsTable)
+    .where(
+      and(
+        dateFrom ? gte(dashboardQueueHourlyStatsTable.bucketStart, dateFrom) : undefined,
+        dateTo ? lt(dashboardQueueHourlyStatsTable.bucketStart, dateTo) : undefined,
+      ),
+    )
+    .groupBy(dashboardQueueHourlyStatsTable.queue)
+    .as("pressure_stats");
+
+type PressureStats = ReturnType<typeof buildPressureStats>;
+
+const getSortExpression = (sortBy: QueueSortBy, pressureStats?: PressureStats) => {
+  if (sortBy === "pressure") {
+    if (!pressureStats) {
+      throw new Error("Pressure sort requires pressure stats");
+    }
+    return sql<number>`COALESCE(${pressureStats.pressure}, 0)`;
+  }
   if (sortBy === "activeJobs") return activeJobsExpression;
   return waitingJobsExpression;
 };
 
 const getCursorValue = (cursor: QueueCursor, sortBy: QueueSortBy) => {
+  if (sortBy === "pressure") {
+    if (cursor.pressure === undefined) {
+      throw new Error("Pressure cursor is required when sorting by pressure");
+    }
+    return cursor.pressure;
+  }
   if (sortBy === "activeJobs") return cursor.activeJobs ?? 0;
   return cursor.waitingJobs;
 };
@@ -53,8 +96,9 @@ const getCursorComparison = (
   cursorDirection: CursorDirection,
   sortBy: QueueSortBy,
   sortDirection: SortDirection,
+  pressureStats?: PressureStats,
 ) => {
-  const sortExpression = getSortExpression(sortBy);
+  const sortExpression = getSortExpression(sortBy, pressureStats);
   const cursorValue = getCursorValue(cursor, sortBy);
   const nameComparison =
     cursorDirection === "next" ? gt(queuesTable.name, cursor.name) : lt(queuesTable.name, cursor.name);
@@ -68,8 +112,13 @@ const getCursorComparison = (
   return or(lt(sortExpression, cursorValue), tiedSortComparison);
 };
 
-const getSortOrder = (cursorDirection: CursorDirection, sortBy: QueueSortBy, sortDirection: SortDirection) => {
-  const sortExpression = getSortExpression(sortBy);
+const getSortOrder = (
+  cursorDirection: CursorDirection,
+  sortBy: QueueSortBy,
+  sortDirection: SortDirection,
+  pressureStats?: PressureStats,
+) => {
+  const sortExpression = getSortExpression(sortBy, pressureStats);
   const orderDirection = getOrderDirection(cursorDirection, sortDirection);
   const sortOrder = orderDirection === "asc" ? asc(sortExpression) : desc(sortExpression);
   const nameOrder = cursorDirection === "next" ? asc(queuesTable.name) : desc(queuesTable.name);
@@ -84,32 +133,29 @@ export const listQueues = async (input: z.input<typeof listQueuesInputSchema> = 
     cursorDirection = "next",
     sortBy = "waitingJobs",
     sortDirection = "desc",
+    pressureDateFrom,
+    pressureDateTo,
   } = listQueuesInputSchema.parse(input);
   const limit = input.limit ?? 20;
-
-  const rows = await db
-    .select({
-      id: queuesTable.id,
-      name: queuesTable.name,
-      isPaused: queuesTable.isPaused,
-      waitingJobs: waitingJobsExpression.as("waiting_jobs"),
-      activeJobs: activeJobsExpression.as("active_jobs"),
-      patterns: sql<string[] | null | undefined>`array_agg(${jobSchedulersTable.pattern})`.as("patterns"),
-      everys: sql<number[] | null | undefined>`array_agg(${jobSchedulersTable.every})`.as("everys"),
-    })
-    .from(queuesTable)
-    .leftJoin(waitingJobCounts, eq(waitingJobCounts.queue, queuesTable.name))
-    .leftJoin(activeJobCounts, eq(activeJobCounts.queue, queuesTable.name))
-    .leftJoin(jobSchedulersTable, eq(jobSchedulersTable.queueId, queuesTable.id))
-    .where(
-      and(
-        cursor ? getCursorComparison(cursor, cursorDirection, sortBy, sortDirection) : undefined,
-        search ? ilike(queuesTable.name, `%${search}%`) : undefined,
-      ),
-    )
-    .groupBy(queuesTable.id, waitingJobCounts.waitingJobs, activeJobCounts.activeJobs)
-    .orderBy(...getSortOrder(cursorDirection, sortBy, sortDirection))
-    .limit(limit + 1);
+  const rows =
+    sortBy === "pressure"
+      ? await listQueuesSortedByPressure({
+          cursor,
+          cursorDirection,
+          limit,
+          pressureDateFrom,
+          pressureDateTo,
+          search,
+          sortDirection,
+        })
+      : await listQueuesSortedByJobCount({
+          cursor,
+          cursorDirection,
+          limit,
+          search,
+          sortBy,
+          sortDirection,
+        });
 
   const hasExtra = rows.length > limit;
 
@@ -136,6 +182,7 @@ export const listQueues = async (input: z.input<typeof listQueuesInputSchema> = 
       everys: row.everys?.filter(Boolean) ?? [],
       waitingJobs: Number(row.waitingJobs ?? 0),
       activeJobs: Number(row.activeJobs ?? 0),
+      pressure: Number(row.pressure ?? 0),
     })),
     nextCursor:
       hasOlderPage && lastRow
@@ -143,6 +190,7 @@ export const listQueues = async (input: z.input<typeof listQueuesInputSchema> = 
             name: lastRow.name,
             waitingJobs: Number(lastRow.waitingJobs ?? 0),
             activeJobs: Number(lastRow.activeJobs ?? 0),
+            pressure: Number(lastRow.pressure ?? 0),
           }
         : null,
     prevCursor:
@@ -151,8 +199,84 @@ export const listQueues = async (input: z.input<typeof listQueuesInputSchema> = 
             name: firstRow.name,
             waitingJobs: Number(firstRow.waitingJobs ?? 0),
             activeJobs: Number(firstRow.activeJobs ?? 0),
+            pressure: Number(firstRow.pressure ?? 0),
           }
         : null,
     total: Number(total?.count ?? 0),
   });
 };
+
+async function listQueuesSortedByPressure({
+  cursor,
+  cursorDirection,
+  limit,
+  pressureDateFrom,
+  pressureDateTo,
+  search,
+  sortDirection,
+}: {
+  cursor: QueueCursor | null | undefined;
+  cursorDirection: CursorDirection;
+  limit: number;
+  pressureDateFrom?: Date;
+  pressureDateTo?: Date;
+  search?: string;
+  sortDirection: SortDirection;
+}) {
+  const pressureStats = buildPressureStats(pressureDateFrom, pressureDateTo);
+
+  return db
+    .select({
+      ...queueSelectFields,
+      pressure: pressureStats.pressure,
+    })
+    .from(queuesTable)
+    .leftJoin(waitingJobCounts, eq(waitingJobCounts.queue, queuesTable.name))
+    .leftJoin(activeJobCounts, eq(activeJobCounts.queue, queuesTable.name))
+    .leftJoin(pressureStats, eq(pressureStats.queue, queuesTable.name))
+    .leftJoin(jobSchedulersTable, eq(jobSchedulersTable.queueId, queuesTable.id))
+    .where(
+      and(
+        cursor ? getCursorComparison(cursor, cursorDirection, "pressure", sortDirection, pressureStats) : undefined,
+        search ? ilike(queuesTable.name, `%${search}%`) : undefined,
+      ),
+    )
+    .groupBy(queuesTable.id, waitingJobCounts.waitingJobs, activeJobCounts.activeJobs, pressureStats.pressure)
+    .orderBy(...getSortOrder(cursorDirection, "pressure", sortDirection, pressureStats))
+    .limit(limit + 1);
+}
+
+async function listQueuesSortedByJobCount({
+  cursor,
+  cursorDirection,
+  limit,
+  search,
+  sortBy,
+  sortDirection,
+}: {
+  cursor: QueueCursor | null | undefined;
+  cursorDirection: CursorDirection;
+  limit: number;
+  search?: string;
+  sortBy: Exclude<QueueSortBy, "pressure">;
+  sortDirection: SortDirection;
+}) {
+  return db
+    .select({
+      ...queueSelectFields,
+      pressure: sql<number>`0`.as("pressure"),
+    })
+    .from(queuesTable)
+    .leftJoin(waitingJobCounts, eq(waitingJobCounts.queue, queuesTable.name))
+    .leftJoin(activeJobCounts, eq(activeJobCounts.queue, queuesTable.name))
+    .leftJoin(jobSchedulersTable, eq(jobSchedulersTable.queueId, queuesTable.id))
+    .where(
+      and(
+        cursor ? getCursorComparison(cursor, cursorDirection, sortBy, sortDirection) : undefined,
+        search ? ilike(queuesTable.name, `%${search}%`) : undefined,
+      ),
+    )
+    .groupBy(queuesTable.id, waitingJobCounts.waitingJobs, activeJobCounts.activeJobs)
+    .orderBy(...getSortOrder(cursorDirection, sortBy, sortDirection))
+    .limit(limit + 1);
+}

--- a/packages/db/drizzle/0020_queue_pressure_rollups.sql
+++ b/packages/db/drizzle/0020_queue_pressure_rollups.sql
@@ -1,0 +1,70 @@
+ALTER TABLE "dashboard_queue_hourly_stats"
+  ADD COLUMN IF NOT EXISTS "pressure_total_ms" bigint DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "dashboard_queue_hourly_stats"
+  ADD COLUMN IF NOT EXISTS "pressure_count" bigint DEFAULT 0 NOT NULL;
+--> statement-breakpoint
+INSERT INTO "dashboard_queue_hourly_stats" (
+  "bucket_start",
+  "queue",
+  "total_runs",
+  "completed_runs",
+  "failed_runs",
+  "active_runs",
+  "waiting_runs",
+  "duration_total_ms",
+  "duration_count",
+  "duration_min_ms",
+  "duration_max_ms",
+  "pressure_total_ms",
+  "pressure_count",
+  "updated_at"
+)
+SELECT
+  date_trunc('hour', "created_at")::timestamp AS "bucket_start",
+  "queue",
+  COUNT(*)::bigint AS "total_runs",
+  COUNT(*) FILTER (WHERE "status" = 'completed'::"job_status")::bigint AS "completed_runs",
+  COUNT(*) FILTER (WHERE "status" = 'failed'::"job_status")::bigint AS "failed_runs",
+  COUNT(*) FILTER (WHERE "status" = 'active'::"job_status")::bigint AS "active_runs",
+  COUNT(*) FILTER (WHERE "status" = 'waiting'::"job_status")::bigint AS "waiting_runs",
+  COALESCE(
+    SUM("duration_ms") FILTER (
+      WHERE "status" = 'completed'::"job_status"
+        AND "duration_ms" IS NOT NULL
+    ),
+    0
+  )::bigint AS "duration_total_ms",
+  COUNT("duration_ms") FILTER (
+    WHERE "status" = 'completed'::"job_status"
+      AND "duration_ms" IS NOT NULL
+  )::bigint AS "duration_count",
+  MIN("duration_ms") FILTER (
+    WHERE "status" = 'completed'::"job_status"
+      AND "duration_ms" IS NOT NULL
+  )::integer AS "duration_min_ms",
+  MAX("duration_ms") FILTER (
+    WHERE "status" = 'completed'::"job_status"
+      AND "duration_ms" IS NOT NULL
+  )::integer AS "duration_max_ms",
+  COALESCE(
+    SUM(EXTRACT(EPOCH FROM ("started_at" - "enqueued_at")) * 1000) FILTER (
+      WHERE "status" IN ('completed'::"job_status", 'failed'::"job_status")
+        AND "enqueued_at" IS NOT NULL
+        AND "started_at" IS NOT NULL
+    ),
+    0
+  )::bigint AS "pressure_total_ms",
+  COUNT(*) FILTER (
+    WHERE "status" IN ('completed'::"job_status", 'failed'::"job_status")
+      AND "enqueued_at" IS NOT NULL
+      AND "started_at" IS NOT NULL
+  )::bigint AS "pressure_count",
+  now()
+FROM "job_runs"
+WHERE "created_at" >= now() - interval '30 days'
+GROUP BY date_trunc('hour', "created_at")::timestamp, "queue"
+ON CONFLICT ("bucket_start", "queue") DO UPDATE SET
+  "pressure_total_ms" = EXCLUDED."pressure_total_ms",
+  "pressure_count" = EXCLUDED."pressure_count",
+  "updated_at" = now();

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1777047100000,
       "tag": "0019_mcp_oauth",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1777047200000,
+      "tag": "0020_queue_pressure_rollups",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schemas/dashboard/schema.ts
+++ b/packages/db/src/schemas/dashboard/schema.ts
@@ -15,6 +15,8 @@ export const dashboardQueueHourlyStatsTable = pgTable(
     durationCount: bigint("duration_count", { mode: "number" }).notNull().default(0),
     durationMinMs: integer("duration_min_ms"),
     durationMaxMs: integer("duration_max_ms"),
+    pressureTotalMs: bigint("pressure_total_ms", { mode: "number" }).notNull().default(0),
+    pressureCount: bigint("pressure_count", { mode: "number" }).notNull().default(0),
     updatedAt: timestamp("updated_at", { precision: 3, mode: "date" }).notNull().default(sql`now()`),
   },
   (t) => [primaryKey({ name: "pk_dashboard_queue_hourly_stats", columns: [t.bucketStart, t.queue] })],

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -13,7 +13,7 @@ import {
   queueMutationInputSchema,
 } from "@better-bull-board/core/mutation-schemas";
 import { getSystemOverview, systemOverviewSchema } from "@better-bull-board/core/overview";
-import { listQueuesInputSchema, listQueuesOutputSchema } from "@better-bull-board/core/queue-schemas";
+import { listQueuesBaseInputSchema, type listQueuesOutputSchema } from "@better-bull-board/core/queue-schemas";
 import { listQueues } from "@better-bull-board/core/queues";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
@@ -21,6 +21,47 @@ import { cancelJob, deleteQueue, pauseQueue, replayJob, resumeQueue } from "./ac
 import { MCP_READ_SCOPE, MCP_WRITE_SCOPE } from "./scopes";
 
 const emptyInputSchema = z.object({}).strict();
+
+const mcpListQueuesInputSchema = listQueuesBaseInputSchema
+  .omit({ pressureDateFrom: true, pressureDateTo: true })
+  .extend({
+    cursor: z
+      .object({
+        waitingJobs: z.number(),
+        activeJobs: z.number().optional(),
+        name: z.string(),
+      })
+      .nullish(),
+    sortBy: z.enum(["waitingJobs", "activeJobs"]).optional().default("waitingJobs"),
+  });
+
+const mcpListQueuesOutputSchema = z.object({
+  queues: z.array(
+    z.object({
+      name: z.string(),
+      isPaused: z.boolean(),
+      patterns: z.array(z.string()),
+      everys: z.array(z.number()),
+      waitingJobs: z.number(),
+      activeJobs: z.number(),
+    }),
+  ),
+  nextCursor: z
+    .object({
+      waitingJobs: z.number(),
+      activeJobs: z.number(),
+      name: z.string(),
+    })
+    .nullable(),
+  prevCursor: z
+    .object({
+      waitingJobs: z.number(),
+      activeJobs: z.number(),
+      name: z.string(),
+    })
+    .nullable(),
+  total: z.number(),
+});
 
 type BetterBullBoardMcpServerOptions = {
   scopes?: string[];
@@ -100,7 +141,28 @@ const formatOverview = (overview: z.infer<typeof systemOverviewSchema>) =>
     `- Queues with schedulers: ${overview.queuesWithSchedulers}`,
   ].join("\n");
 
-const formatQueues = (result: z.infer<typeof listQueuesOutputSchema>) =>
+const serializeQueues = (
+  result: z.infer<typeof listQueuesOutputSchema>,
+): z.infer<typeof mcpListQueuesOutputSchema> => ({
+  queues: result.queues.map(({ pressure: _pressure, ...queue }) => queue),
+  nextCursor: result.nextCursor
+    ? {
+        name: result.nextCursor.name,
+        waitingJobs: result.nextCursor.waitingJobs,
+        activeJobs: result.nextCursor.activeJobs,
+      }
+    : null,
+  prevCursor: result.prevCursor
+    ? {
+        name: result.prevCursor.name,
+        waitingJobs: result.prevCursor.waitingJobs,
+        activeJobs: result.prevCursor.activeJobs,
+      }
+    : null,
+  total: result.total,
+});
+
+const formatQueues = (result: z.infer<typeof mcpListQueuesOutputSchema>) =>
   [
     "# Better Bull Board Queues",
     "",
@@ -220,8 +282,8 @@ export const createBetterBullBoardMcpServer = (options: BetterBullBoardMcpServer
       title: "List Better Bull Board Queues",
       description:
         "List queues with waiting and active job counts. Supports search, cursor pagination, and a maximum page size of 100.",
-      inputSchema: listQueuesInputSchema,
-      outputSchema: listQueuesOutputSchema,
+      inputSchema: mcpListQueuesInputSchema,
+      outputSchema: mcpListQueuesOutputSchema,
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -231,10 +293,11 @@ export const createBetterBullBoardMcpServer = (options: BetterBullBoardMcpServer
     },
     async (input) => {
       const result = await listQueues(input);
+      const serializedResult = serializeQueues(result);
 
       return {
-        content: [{ type: "text", text: formatQueues(result) }],
-        structuredContent: result,
+        content: [{ type: "text", text: formatQueues(serializedResult) }],
+        structuredContent: serializedResult,
       };
     },
   );


### PR DESCRIPTION
Add pressure as a sortable metric in the queues table using hourly dashboard rollups instead of per-request job run scans. Missing pressure rollups are treated as zero, and existing queue list callers keep their current behavior unless pressure sorting is requested.

**Rollup-backed pressure**

Dashboard rollups now store pressure totals and counts, with a migration that backfills full hourly rows for the retained 30-day window. Pressure sorting requires a bounded date window so direct core callers cannot trigger unbounded rollup aggregation.

**API compatibility**

The app injects the pressure window server-side, while MCP keeps its existing queue list input and output schema without exposing pressure sorting or pressure fields.
